### PR TITLE
Add SchemaNode.__contains__ to support "name in schema".

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1399,6 +1399,13 @@ class SchemaNode(object):
         """ Iterate over the children nodes of this schema node """
         return iter(self.children)
 
+    def __contains__(self, name):
+        try:
+            self[name]
+        except KeyError:
+            return False
+        return True
+
     def __repr__(self):
         return '<%s.%s object at %d (named %s)>' % (
             self.__module__,

--- a/colander/tests.py
+++ b/colander/tests.py
@@ -1503,6 +1503,13 @@ class TestSchemaNode(unittest.TestCase):
         it = node.__iter__()
         self.assertEqual(list(it), ['a', 'b', 'c'])
 
+    def test___contains__(self):
+        node = self._makeOne(None)
+        another = self._makeOne(None, name='another')
+        node.add(another)
+        self.assertEquals('another' in node, True)
+        self.assertEquals('b' in node, False)
+
     def test_clone(self):
         inner_typ = DummyType()
         outer_typ = DummyType()


### PR DESCRIPTION
Add SchemaNode.**contains** to support "name in schema".

This should be useful for conditional imperative manipulation of
existing schemas.  Note that this changes the behaviour of "in
schema", which used to be "does it contain this node instance" instead
of "does it contain a node with this name".  Maybe this was done
deliberately so.
