### PR TITLE
Consider 'default_tzinfo' when deserializing naive datetimes. 

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1118,7 +1118,8 @@ class DateTime(SchemaType):
             return null
         
         try:
-            result = iso8601.parse_date(cstruct)
+            result = iso8601.parse_date(
+                cstruct, default_timezone=self.default_tzinfo)
         except (iso8601.ParseError, TypeError), e:
             try:
                 year, month, day = map(int, cstruct.split('-', 2))

--- a/colander/tests.py
+++ b/colander/tests.py
@@ -1312,7 +1312,18 @@ class TestDateTime(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.deserialize(node, iso)
         self.assertEqual(result.isoformat(), iso)
-        
+
+    def test_deserialize_naive_with_default_tzinfo(self):
+        import iso8601
+        tzinfo = iso8601.iso8601.FixedOffset(1, 0, 'myname')
+        typ = self._makeOne(default_tzinfo=tzinfo)
+        dt = self._dt()
+        dt_with_tz = dt.replace(tzinfo=tzinfo)
+        iso = dt.isoformat()
+        node = DummySchemaNode(None)
+        result = typ.deserialize(node, iso)
+        self.assertEqual(result.isoformat(), dt_with_tz.isoformat())
+
 class TestDate(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import Date


### PR DESCRIPTION
Before, iso dates without timezone always became UTC regardless of
'Datetime.default_tzinfo'.
