### PR TITLE
Allow None as 'default_tzinfo' of DateTime.

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1091,8 +1091,8 @@ class DateTime(SchemaType):
     """
     err_template =  _('Invalid date')
 
-    def __init__(self, default_tzinfo=None):
-        if default_tzinfo is None:
+    def __init__(self, default_tzinfo=_marker):
+        if default_tzinfo is _marker:
             default_tzinfo = iso8601.iso8601.Utc()
         self.default_tzinfo = default_tzinfo
         

--- a/colander/tests.py
+++ b/colander/tests.py
@@ -1258,6 +1258,13 @@ class TestDateTime(unittest.TestCase):
         expected = dt.replace(tzinfo=typ.default_tzinfo).isoformat()
         self.assertEqual(result, expected)
 
+    def test_serialize_with_none_tzinfo_naive_datetime(self):
+        typ = self._makeOne(default_tzinfo=None)
+        node = DummySchemaNode(None)
+        dt = self._dt()
+        result = typ.serialize(node, dt)
+        self.assertEqual(result, dt.isoformat())
+
     def test_serialize_with_tzware_datetime(self):
         import iso8601
         typ = self._makeOne()
@@ -1323,6 +1330,14 @@ class TestDateTime(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.deserialize(node, iso)
         self.assertEqual(result.isoformat(), dt_with_tz.isoformat())
+
+    def test_deserialize_none_tzinfo(self):
+        typ = self._makeOne(default_tzinfo=None)
+        dt = self._dt()
+        iso = dt.isoformat()
+        node = DummySchemaNode(None)
+        result = typ.deserialize(node, iso)
+        self.assertEqual(result.isoformat(), dt.isoformat())
 
 class TestDate(unittest.TestCase):
     def _makeOne(self, *arg, **kw):


### PR DESCRIPTION
Another small enhancement to colander.DateTime.

This allows us to use DateTime without a timezone info entirely. An example:

```
start = colander.SchemaNode(
    colander.DateTime(default_tzinfo=None))
```

(I need to store these without timezone since there's no timezone support at least with SQLAlchemy/SQLite.)
