### PR TITLE
stop sphinx warning whine

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ release = version
 today_fmt = '%B %d, %Y'
 
 # List of documents that shouldn't be included in the build.
-#unused_docs = []
+unused_docs = ['_themes/README']
 
 # List of directories, relative to source directories, that shouldn't be
 # searched for source files.


### PR DESCRIPTION
A tiny change to stop the whine about the README in the _theme dir.
