### PR TITLE
Instantiate decorator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,9 @@ Next release
   deserialization and validation. See the Preparing section in the
   documentation.
 
+- Add ``colander.instantiate`` to help define schemas containing
+  mappings and sequences more succinctly.
+
 0.9.2 (2011-03-28)
 ------------------
 

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1517,3 +1517,17 @@ class deferred(object):
     def __call__(self, node, kw):
         return self.wrapped(node, kw)
 
+class instantiate(object):
+    """
+    A decorator which can be used to instantiate :class:`SchemaNode`
+    elements inline within a class definition.
+
+    All parameters passed to the decorator and passed along to the
+    :class:`SchemaNode` during instantiation.
+    """
+    
+    def __init__(self,*args,**kw):
+        self.args,self.kw = args,kw
+        
+    def __call__(self,class_):
+        return class_(*self.args,**self.kw)

--- a/colander/tests.py
+++ b/colander/tests.py
@@ -1995,6 +1995,42 @@ class TestDeclarative(unittest.TestCase, TestFunctional):
         schema = MainSchema(name='schema')
         return schema
 
+class TestDeclarativeWithInstantiate(unittest.TestCase, TestFunctional):
+    
+    def _makeSchema(self):
+
+        import colander
+
+        # an unlikely usage, but goot to test passing
+        # parameters to instantiation works
+        @colander.instantiate(name='schema')
+        class schema(colander.MappingSchema):
+            int = colander.SchemaNode(colander.Int(),
+                                     validator=colander.Range(0, 10))
+            ob = colander.SchemaNode(colander.GlobalObject(package=colander))
+            @colander.instantiate()
+            class seq(colander.SequenceSchema):
+                
+                @colander.instantiate()
+                class tup(colander.TupleSchema):
+                    tupint = colander.SchemaNode(colander.Int())
+                    tupstring = colander.SchemaNode(colander.String())
+                    
+            @colander.instantiate()
+            class tup(colander.TupleSchema):
+                tupint = colander.SchemaNode(colander.Int())
+                tupstring = colander.SchemaNode(colander.String())
+                
+            @colander.instantiate()
+            class seq2(colander.SequenceSchema):
+                
+                @colander.instantiate()
+                class mapping(colander.MappingSchema):
+                    key = colander.SchemaNode(colander.Int())
+                    key2 = colander.SchemaNode(colander.Int())
+
+        return schema
+
 class Test_null(unittest.TestCase):
     def test___nonzero__(self):
         from colander import null

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -120,6 +120,8 @@ Schema-Related
 
   .. autoclass:: deferred
 
+  .. autoclass:: instantiate
+
   .. attribute:: null
 
      Represents a null value in colander-related operations.

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -503,6 +503,67 @@ The corollary: it is the responsibility of the developer to ensure he
 serializes "the right" data; :mod:`colander` will not raise an error
 when asked to serialize something that is partially nonsense.
 
+Defining A Schema Declaratively
+-------------------------------
+
+Previously, we defined the schema in such a way that the individual
+sequences and mappings within the schema could be re-used in different
+schemas.
+
+If all nodes within a schema are only likely to be used in that
+schema, then the schema definition can be made more succinct using the
+:class:`~colander.instantiate` class decorator as shown below:
+
+.. code-block:: python
+   :linenos:
+
+   import colander
+
+   class Person(colander.MappingSchema):
+       name = colander.SchemaNode(colander.String())
+       age = colander.SchemaNode(colander.Int(),
+                                 validator=colander.Range(0, 200))
+
+       @colander.instantiate()
+       class friends(colander.SequenceSchema):
+
+           @colander.instantiate()
+           class friend(colander.TupleSchema):
+               rank = colander.SchemaNode(colander.Int(), 
+                                          validator=colander.Range(0, 9999))
+               name = colander.SchemaNode(colander.String())
+
+       @colander.instantiate()
+       class phones(colander.SequenceSchema):
+
+           @colander.instantiate()
+           class phone(colander.MappingSchema):
+               location = colander.SchemaNode(colander.String(), 
+                                              validator=colander.OneOf(['home', 'work']))
+               number = colander.SchemaNode(colander.String())
+
+When using this style of schema definition, if you need to pass
+parameters, such as a ``missing`` value to a :class:`SchemaNode`
+during instantiation, you can pass these as parameters to
+:class:`~colander.instantiate`.
+
+For example, if we wanted to limit the number of friends a person can
+have, and cater for people who have no friends, we could adjust the
+schema as shown below:
+
+.. code-block:: python
+   :linenos:
+
+   class Person(colander.MappingSchema):
+
+       @colander.instantiate(missing=(),
+                             validator=colander.Length(max=5))
+       class friends(colander.SequenceSchema):
+
+           @colander.instantiate()
+           class friend(colander.TupleSchema):
+               name = colander.SchemaNode(colander.String())
+
 Defining A Schema Imperatively
 ------------------------------
 


### PR DESCRIPTION
As shown in the docs in the patch, I've found this to be a handy way of defining schemas containing sequences and mappings where those nodes are only used within the one schema.

cheers,

Chris
