### PR TITLE
Invalid.messages() should return an empty list if there are no messages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,9 @@ Unreleased
 - Added ``get_value`` and ``set_value`` methods to ``Schema`` which allow
   access and mutation of appstructs using dotted name paths.
 
+- The ``messages`` method of ``Invalid`` now returns an empty list
+  when there are no messages.
+
 0.9.3 (2011-06-23)
 ------------------
 

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -62,10 +62,13 @@ class Invalid(Exception):
         """ Return an iterable of error messages for this exception
         using the ``msg`` attribute of this error node.  If the
         ``msg`` attribute is iterable, it is returned.  If it is not
-        iterable, a single-element list containing the ``msg`` value
-        is returned."""
+        iterable, and is not ``None``, a single-element list
+        containing the ``msg`` value is returned.  If ``msg`` is ``None``,
+        an empty list is returned."""
         if hasattr(self.msg, '__iter__'):
             return self.msg
+        elif self.msg is None:
+            return []
         return [self.msg]
 
     def add(self, exc, pos=None):

--- a/colander/tests.py
+++ b/colander/tests.py
@@ -136,6 +136,11 @@ class TestInvalid(unittest.TestCase):
         exc = self._makeOne(node, 'msg')
         self.assertEqual(exc.messages(), ['msg'])
 
+    def test_messages_msg_none(self):
+        node = DummySchemaNode(None)
+        exc = self._makeOne(node)
+        self.assertEqual(exc.messages(), [])
+
 class TestAll(unittest.TestCase):
     def _makeOne(self, validators):
         from colander import All


### PR DESCRIPTION
Currently, the `messages` method of `Invalid` returns `[None]` (a list of length one) if the `msg` attribute is `None`.  This seems non-useful.  This fixes things so that an empty list is returned when there are no messages.
