### PR TITLE
Fix invalid.asdict for multiple error messages.

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -147,7 +147,7 @@ class Invalid(Exception):
             keyparts = []
             msgs = []
             for exc in path:
-                exc.msg and msgs.append(exc.msg)
+                exc.msg and msgs.extend(exc.messages())
                 keyname = exc._keyname()
                 keyname and keyparts.append(keyname)
             errors['.'.join(keyparts)] = '; '.join(interpolate(msgs))

--- a/colander/tests.py
+++ b/colander/tests.py
@@ -81,7 +81,7 @@ class TestInvalid(unittest.TestCase):
         exc1.pos = 1
         exc2 = self._makeOne(node2, 'exc2')
         exc3 = self._makeOne(node3, 'exc3')
-        exc4 = self._makeOne(node4, 'exc4')
+        exc4 = self._makeOne(node4, ['exc4'])
         exc1.add(exc2, 2)
         exc2.add(exc3, 3)
         exc1.add(exc4, 4)


### PR DESCRIPTION
Using All returns a list of error messages.  It is not safe to assume
then that exc.msg returns a single string.
