### PR TITLE
Enable colander.Function to use ${val} in error message

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -225,9 +225,9 @@ class Function(object):
     def __call__(self, node, value):
         result = self.function(value)
         if not result:
-            raise Invalid(node, self.message)
+            raise Invalid(node, translationstring.TranslationString(self.message, mapping={'val':value}))
         if isinstance(result, string_types):
-            raise Invalid(node, result)
+            raise Invalid(node, translationstring.TranslationString(result, mapping={'val':value}))
 
 class Regex(object):
     """ Regular expression validator.

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -243,6 +243,30 @@ class TestFunction(unittest.TestCase):
         e = invalid_exc(validator, None, None)
         self.assertEqual(e.msg, 'fail')
 
+    def test_error_message_adds_mapping_to_configured_message(self):
+        validator = self._makeOne(lambda x: False, message='fail ${val}')
+        e = invalid_exc(validator, None, None)
+        self.assertEqual(e.msg.interpolate(), 'fail None')
+
+    def test_error_message_adds_mapping_to_return_message(self):
+        validator = self._makeOne(lambda x: 'fail ${val}')
+        e = invalid_exc(validator, None, None)
+        self.assertEqual(e.msg.interpolate(), 'fail None')
+
+    def test_error_message_does_not_overwrite_configured_domain(self):
+        import translationstring
+        _ = translationstring.TranslationStringFactory('fnord')
+        validator = self._makeOne(lambda x: False, message=_('fail ${val}'))
+        e = invalid_exc(validator, None, None)
+        self.assertEqual(e.msg.domain, 'fnord')
+
+    def test_error_message_does_not_overwrite_returned_domain(self):
+        import translationstring
+        _ = translationstring.TranslationStringFactory('fnord')
+        validator = self._makeOne(lambda x: _('fail ${val}'))
+        e = invalid_exc(validator, None, None)
+        self.assertEqual(e.msg.domain, 'fnord')
+
     def test_propagation(self):
         validator = self._makeOne(lambda x: 'a' in x, 'msg')
         self.assertRaises(TypeError, validator, None, None)


### PR DESCRIPTION
oh well, the lack of shell escaping foobared the commit message :-/
