### PR TITLE
documentation fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,9 @@ Next release
 
 - Updated Japanese translation.
 
+- Fix documentation: 0.9.3 allowed explicitly passing None to DateTime
+  to have no default timezone applied.
+
 0.9.7 (2012-03-20)
 ------------------
 

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1188,11 +1188,12 @@ class DateTime(SchemaType):
     datetime.
 
     The constructor accepts an argument named ``default_tzinfo`` which
-    should be a Python ``tzinfo`` object; by default it is None,
-    meaning that the default tzinfo will be equivalent to UTC (Zulu
-    time).  The ``default_tzinfo`` tzinfo object is used to convert
-    'naive' datetimes to a timezone-aware representation during
-    serialization.
+    should be a Python ``tzinfo`` object. If ``default_tzinfo`` is not
+    specified the default tzinfo will be equivalent to UTC (Zulu time).
+    The ``default_tzinfo`` tzinfo object is used to convert 'naive'
+    datetimes to a timezone-aware representation during serialization.
+    If ``default_tzinfo`` is explicitly set to ``None`` then no default
+    tzinfo will be applied to naive datetimes.
 
     You can adjust the error message reported by this class by
     changing its ``err_template`` attribute in a subclass on an

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -1531,10 +1531,14 @@ class TestDateTime(unittest.TestCase):
         import datetime
         return datetime.date.today()
 
-    def test_ctor_default_tzinfo_None(self):
+    def test_ctor_default_tzinfo_not_specified(self):
         from .. import iso8601
         typ = self._makeOne()
         self.assertEqual(typ.default_tzinfo.__class__, iso8601.Utc)
+
+    def test_ctor_default_tzinfo_None(self):
+        typ = self._makeOne(default_tzinfo=None)
+        self.assertEqual(typ.default_tzinfo, None)
 
     def test_ctor_default_tzinfo_non_None(self):
         from .. import iso8601
@@ -1663,6 +1667,7 @@ class TestDateTime(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.deserialize(node, iso)
         self.assertEqual(result.isoformat(), dt.isoformat())
+        self.assertEqual(result.tzinfo, None)
 
 class TestDate(unittest.TestCase):
     def _makeOne(self, *arg, **kw):


### PR DESCRIPTION
0.9.3 allowed explicitly passing None to DateTime
to have no default timezone applied.

Also tighten up the tests for this a bit.
