### PR TITLE
Mappings now deserialize None to colander.null.

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -489,7 +489,7 @@ class Mapping(SchemaType):
         return self._impl(node, appstruct, callback)
 
     def deserialize(self, node, cstruct):
-        if cstruct is null:
+        if cstruct in (null, None):
             return null
 
         def callback(subnode, subcstruct):


### PR DESCRIPTION
This makes `missing=` possible for mappings when the cstruct's value
is None (such as when we encounted deserialized JSON 'null' values).
