### PR TITLE
Make declarative definition of a schema possible to determine child nodes’ particular order.

### DIFF
--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2180,7 +2180,24 @@ class TestSchemaNode(unittest.TestCase):
                 )
         schema = FnordSchema()
         self.assertEqual(schema['fnord[]'].name, 'fnord[]')
-        
+
+    def test_insert_before(self):
+        import colander
+        class BaseSchema(colander.Schema):
+            b = colander.SchemaNode(colander.Integer())
+            d = colander.SchemaNode(colander.Integer())
+        class DeriveredSchema(BaseSchema):
+            e = colander.SchemaNode(colander.Integer())
+            c = colander.SchemaNode(colander.Integer(), insert_before='d')
+            a = colander.SchemaNode(colander.Integer(), insert_before='b')
+            f = colander.SchemaNode(colander.Integer())
+        class WrongInsertBefore(BaseSchema):
+            e = colander.SchemaNode(colander.Integer(), insert_before='f')
+        child_names = [node.name for node in DeriveredSchema().children]
+        self.assertEqual(['a', 'b', 'c', 'd', 'e', 'f'], child_names)
+        with self.assertRaises(LookupError):
+            WrongInsertBefore()
+
 class TestDeferred(unittest.TestCase):
     def _makeOne(self, wrapped):
         from colander import deferred


### PR DESCRIPTION
This patch includes two additional parameters.

The optional `pos` parameter of `SchemaNode.add()` method is useful when an added node should be placed in the particular position, in imperative way.

The optional `insert_before` parameter of `SchemaNode` constructor make child nodes possible to determine their particular order in subclassing.  For example:

``` python
class BaseSchema(colander.Schema):
    b = colander.SchemaNode(colander.Integer())
    d = colander.SchemaNode(colander.Integer())

class DeriveredSchema(BaseSchema):
    e = colander.SchemaNode(colander.Integer())
    c = colander.SchemaNode(colander.Integer(), insert_before='d')
    a = colander.SchemaNode(colander.Integer(), insert_before='b')
    f = colander.SchemaNode(colander.Integer())
```

In the above example, `DeriveredSchema` will have children in the order of `a`, `b`, `c`, `d`, `e`, `f`.

I’m not sure how suitable is this patch for the philosophy of Colander, but I think we need any way to determine order of child nodes in subclassing.

Thank you!
