### PR TITLE
allowing use of None as missing for Numbers

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -951,7 +951,7 @@ class Number(SchemaType):
     num = None
 
     def serialize(self, node, appstruct):
-        if appstruct is null:
+        if not appstruct:
             return null
 
         try:

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -1148,6 +1148,14 @@ class TestInteger(unittest.TestCase):
         result = typ.serialize(node, val)
         self.assertEqual(result, colander.null)
 
+    def test_serialize_none(self):
+        import colander
+        val = None
+        node = DummySchemaNode(None)
+        typ = self._makeOne()
+        result = typ.serialize(node, val)
+        self.assertEqual(result, colander.null)
+
     def test_serialize_emptystring(self):
         import colander
         val = ''


### PR DESCRIPTION
allowing use of None as missing for Numbers, as for DateTime and Strings see pull request #32
