### PR TITLE
Make String serialize empty string to empty string instead of null

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -982,7 +982,7 @@ class String(SchemaType):
         self.encoding = encoding
 
     def serialize(self, node, appstruct):
-        if not appstruct:
+        if appstruct in (null, None):
             return null
 
         try:

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -1182,6 +1182,14 @@ class TestString(unittest.TestCase):
         result = typ.serialize(node, val)
         self.assertEqual(result, colander.null)
 
+    def test_serialize_emptystring(self):
+        import colander
+        val = u''
+        node = DummySchemaNode(None)
+        typ = self._makeOne()
+        result = typ.serialize(node, val)
+        self.assertEqual(result, val)
+
     def test_serialize_uncooperative(self):
         val = Uncooperative()
         node = DummySchemaNode(None)


### PR DESCRIPTION
This makes the following True:
`String().serialize(node, u'') == u''`

Issue #72
