### PR TITLE
Documentation fixes.

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -293,7 +293,7 @@ methods:
 If the things you're trying to defer aren't callables like ``validator``, but
 they're instead just plain attributes like ``missing`` or ``default``,
 instead of using a ``colander.deferred``, you can use ``after_bind`` to set
-attributes of the schemanode that rely on binding variables::
+attributes of the schemanode that rely on binding variables:
 
 .. code-block:: python
 


### PR DESCRIPTION
So far this fixes a single typo typo in the docs.
