### PR TITLE
Drop optional fields during deserialization with missing=colander.drop

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -40,6 +40,15 @@ class _null(object):
 
 null = _null()
 
+class _drop(object):
+    """
+    Represents a value that should be dropped if it is missing during
+    deserialization.
+    """
+    pass
+
+drop = _drop()
+
 def interpolate(msgs):
     for s in msgs:
         if hasattr(s, 'interpolate'):
@@ -531,11 +540,14 @@ class Mapping(SchemaType):
             name = subnode.name
             subval = value.pop(name, null)
             try:
-                result[name] = callback(subnode, subval)
+                sub_result = callback(subnode, subval)
             except Invalid as e:
                 if error is None:
                     error = Invalid(node)
                 error.add(e, num)
+            else:
+                if sub_result is not drop:
+                    result[name] = sub_result
 
         if self.unknown == 'raise':
             if value:

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2895,6 +2895,16 @@ class TestSchema(unittest.TestCase):
         self.assertEqual(node.children[2].title, '')
         self.assertEqual(node.children[3].title, 'thing2')
 
+    def test_deserialize_drop(self):
+        import colander
+        class MySchema(colander.Schema):
+            a = colander.SchemaNode(colander.String())
+            b = colander.SchemaNode(colander.String(), missing=colander.drop)
+        node = MySchema()
+        expected = {'a': 'test'}
+        result = node.deserialize(expected)
+        self.assertEqual(result, expected)
+
 class TestSequenceSchema(unittest.TestCase):
     def test_succeed(self):
         import colander


### PR DESCRIPTION
This pull request addresses issue #60.

The change updates MappingSchema to watch for a new `colander.drop` value during deserialization. If a node deserializes to that value, it is excluded from the schema's deserialized output.
