### PR TITLE
 Improve email address validator regex & add tests re: #82.

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -272,10 +272,11 @@ class Email(Regex):
         otherwise, defaults to 'Invalid email address'.
     """
     def __init__(self, msg=None):
+        email_regex = text_(
+            '(?i)^[A-Z0-9._%+-]+@[A-Z0-9]+([.-][A-Z0-9]+)*\.[A-Z]{2,4}$')
         if msg is None:
             msg = _("Invalid email address")
-        super(Email, self).__init__(
-            text_('(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$'), msg=msg)
+        super(Email, self).__init__(email_regex, msg=msg)
 
 class Range(object):
     """ Validator which succeeds if the value it is passed is greater

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -362,6 +362,8 @@ class TestEmail(unittest.TestCase):
         self.assertRaises(Invalid, validator, None, 'name@here.comcom')
         self.assertRaises(Invalid, validator, None, '@here.us')
         self.assertRaises(Invalid, validator, None, '(name)@here.info')
+        self.assertRaises(Invalid, validator, None, 'me@here..com')
+        self.assertRaises(Invalid, validator, None, 'me@we-here-.com')
 
 class TestLength(unittest.TestCase):
     def _makeOne(self, min=None, max=None):


### PR DESCRIPTION
Added test assertions for the 2 invalid email address patterns described in #82.
Changed email address validator to the one proposed in #82 with a minor correction.
