### PR TITLE
Invalid behaviour of accept_scalar for str in Python 3.

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -846,7 +846,8 @@ class Sequence(Positional, SchemaType):
         self.accept_scalar = accept_scalar
 
     def _validate(self, node, value, accept_scalar):
-        if hasattr(value, '__iter__') and not hasattr(value, 'get'):
+        if hasattr(value, '__iter__') and not hasattr(value, 'get') and \
+                not isinstance(value, string_types):
             return list(value)
         if accept_scalar:
             return [value]

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -1086,6 +1086,13 @@ class TestSequence(unittest.TestCase):
         result = typ.deserialize(node, None)
         self.assertEqual(result, [None])
 
+    def test_deserialize_string_accept_scalar(self):
+        node = DummySchemaNode(None)
+        typ = self._makeOne(accept_scalar=True)
+        node.children = [node]
+        result = typ.deserialize(node, 'abc')
+        self.assertEqual(result, ['abc'])
+
     def test_deserialize_no_subnodes(self):
         typ = self._makeOne()
         node = DummySchemaNode(None)
@@ -1138,6 +1145,13 @@ class TestSequence(unittest.TestCase):
         node.children = [node]
         result = typ.serialize(node, None)
         self.assertEqual(result, [None])
+
+    def test_serialize_string_accept_scalar(self):
+        node = DummySchemaNode(None)
+        typ = self._makeOne(accept_scalar=True)
+        node.children = [node]
+        result = typ.serialize(node, 'abc')
+        self.assertEqual(result, ['abc'])
 
     def test_serialize_no_subnodes(self):
         node = DummySchemaNode(None)


### PR DESCRIPTION
In this issue https://github.com/Pylons/colander/issues/81 was mentioned example:

``` Python
import colander


class DatesSchema(colander.SequenceSchema):
    date = colander.SchemaNode(colander.Date())

if __name__ == '__main__':
    schema = DatesSchema(colander.Sequence(accept_scalar=True))
    data = schema.deserialize(['2013-02-14', '2013-02-15'])
    print data
    # [datetime.date(2013, 2, 14), datetime.date(2013, 2, 15)]
    data = schema.deserialize('2013-02-14')
    print data
    # [datetime.date(2013, 2, 14)]
```

This code works fine in Python 2.7 but in Python 3.3 it returns:

``` Python
colander.Invalid: {'0': 'Invalid date',
 '1': 'Invalid date',
 '2': 'Invalid date',
 '3': 'Invalid date',
 '4': 'Invalid date',
 '5': 'Invalid date',
 '6': 'Invalid date',
 '7': 'Invalid date',
 '8': 'Invalid date',
 '9': 'Invalid date'}
```

The following occurs: colander represent string like a iterable type and put it into list().
Check that value is not a string type and tests for it was added.
