### PR TITLE
Add NoneType for (de)serializing None options for other schematypes

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1622,7 +1622,7 @@ class NoneType(SchemaType):
         return self.typ.serialize(node, appstruct)
 
     def deserialize(self, node, cstruct):
-        if cstruct == '':
+        if cstruct == '' or cstruct is None:
             return None
 
         return self.typ.deserialize(node, cstruct)

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1599,9 +1599,9 @@ def timeparse(t, format):
 
 
 class NoneType(SchemaType):
-    """A type which accept None as value for (de)serialization.
-    When the value is not equla to None, it will use (de)serialization of
-    the given type.
+    """A type which accept serialize None to '' and deserialize '' to None.
+    When the value is not equal to None/'', it will use (de)serialization of
+    the given type. This can be used to make nodes optional.
 
     Example:
 
@@ -1617,12 +1617,12 @@ class NoneType(SchemaType):
 
     def serialize(self, node, appstruct):
         if appstruct is None:
-            return None
+            return ''
 
         return self.typ.serialize(node, appstruct)
 
     def deserialize(self, node, cstruct):
-        if cstruct is None:
+        if cstruct == '':
             return None
 
         return self.typ.deserialize(node, cstruct)

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1597,6 +1597,37 @@ class Time(SchemaType):
 def timeparse(t, format):
     return datetime.datetime(*time.strptime(t, format)[0:6]).time()
 
+
+class NoneType(SchemaType):
+    """A type which accept None as value for (de)serialization.
+    When the value is not equla to None, it will use (de)serialization of
+    the given type.
+
+    Example:
+
+        date = colander.SchemaNode(
+            colander.NoneType(colander.DateTime()),
+            default=None,
+            missing=None,
+        )
+    """
+
+    def __init__(self, typ):
+        self.typ = typ
+
+    def serialize(self, node, appstruct):
+        if appstruct is None:
+            return None
+
+        return self.typ.serialize(node, appstruct)
+
+    def deserialize(self, node, cstruct):
+        if cstruct is None:
+            return None
+
+        return self.typ.deserialize(node, cstruct)
+
+
 def _add_node_children(node, children):
     for n in children:
         insert_before = getattr(n, 'insert_before', None)
@@ -1708,7 +1739,7 @@ class _SchemaNode(object):
             _add_node_children(self, arg[1:])
         else:
             self.typ = self.schema_type()
-        
+
         # bw compat forces us to manufacture a title if one is not supplied
         title = kw.get('title', _marker)
         if title is _marker:
@@ -1999,7 +2030,7 @@ SchemaNode = _SchemaMeta(
     (_SchemaNode,),
     {}
     )
-    
+
 class Schema(SchemaNode):
     schema_type = Mapping
 

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -1592,7 +1592,7 @@ class TestNoneTypeWithBoolean(TestBoolean):
         node = DummySchemaNode(None)
         self.assertEqual(typ.serialize(node, 1), 'true')
         self.assertEqual(typ.serialize(node, True), 'true')
-        self.assertEqual(typ.serialize(node, None), None)
+        self.assertEqual(typ.serialize(node, None), '')
         self.assertEqual(typ.serialize(node, False), 'false')
 
     def test_deserialize(self):
@@ -1603,7 +1603,7 @@ class TestNoneTypeWithBoolean(TestBoolean):
         self.assertEqual(typ.deserialize(node, '0'), False)
         self.assertEqual(typ.deserialize(node, 'true'), True)
         self.assertEqual(typ.deserialize(node, 'other'), True)
-        self.assertEqual(typ.deserialize(node, None), None)
+        self.assertEqual(typ.deserialize(node, ''), None)
 
 
 class TestGlobalObject(unittest.TestCase):

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -1604,6 +1604,7 @@ class TestNoneTypeWithBoolean(TestBoolean):
         self.assertEqual(typ.deserialize(node, 'true'), True)
         self.assertEqual(typ.deserialize(node, 'other'), True)
         self.assertEqual(typ.deserialize(node, ''), None)
+        self.assertEqual(typ.deserialize(node, None), None)
 
 
 class TestGlobalObject(unittest.TestCase):

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -465,7 +465,7 @@ class Test_url_validator(unittest.TestCase):
         val = 'http://example.com'
         result = self._callFUT(val)
         self.assertEqual(result, None)
-        
+
     def test_it_failure(self):
         val = 'not-a-url'
         from colander import Invalid
@@ -727,7 +727,7 @@ class TestMapping(unittest.TestCase):
         node1.children = [node2]
         result = typ.cstruct_children(node1, null)
         self.assertEqual(result, [null])
-        
+
     def test_cstruct_children(self):
         from colander import null
         typ = self._makeOne()
@@ -959,7 +959,7 @@ class TestTuple(unittest.TestCase):
         node1.children = [node2]
         result = typ.cstruct_children(node1, null)
         self.assertEqual(result, [null])
-        
+
     def test_cstruct_children_toomany(self):
         typ = self._makeOne()
         node1 = DummySchemaNode(typ, name='node1')
@@ -1197,7 +1197,7 @@ class TestSequence(unittest.TestCase):
         typ = self._makeOne()
         result = typ.cstruct_children(None, null)
         self.assertEqual(result, SequenceItems([]))
-        
+
     def test_cstruct_children_cstruct_is_non_null(self):
         from colander import SequenceItems
         typ = self._makeOne()
@@ -1581,6 +1581,30 @@ class TestBoolean(unittest.TestCase):
         self.assertEqual(typ.serialize(node, True), 'true')
         self.assertEqual(typ.serialize(node, None), 'false')
         self.assertEqual(typ.serialize(node, False), 'false')
+
+class TestNoneTypeWithBoolean(TestBoolean):
+    def _makeOne(self):
+        from colander import Boolean, NoneType
+        return NoneType(Boolean())
+
+    def test_serialize(self):
+        typ = self._makeOne()
+        node = DummySchemaNode(None)
+        self.assertEqual(typ.serialize(node, 1), 'true')
+        self.assertEqual(typ.serialize(node, True), 'true')
+        self.assertEqual(typ.serialize(node, None), None)
+        self.assertEqual(typ.serialize(node, False), 'false')
+
+    def test_deserialize(self):
+        typ = self._makeOne()
+        node = DummySchemaNode(None)
+        self.assertEqual(typ.deserialize(node, 'false'), False)
+        self.assertEqual(typ.deserialize(node, 'FALSE'), False)
+        self.assertEqual(typ.deserialize(node, '0'), False)
+        self.assertEqual(typ.deserialize(node, 'true'), True)
+        self.assertEqual(typ.deserialize(node, 'other'), True)
+        self.assertEqual(typ.deserialize(node, None), None)
+
 
 class TestGlobalObject(unittest.TestCase):
     def _makeOne(self, package=None):
@@ -2508,7 +2532,7 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
         node = MyNode(missing=5)
         result = node.deserialize(colander.null)
         self.assertEqual(result, 5)
-        
+
     def test_method_values_can_rely_on_binding(self):
         import colander
         class MyNode(colander.SchemaNode):
@@ -2751,14 +2775,14 @@ class TestMappingSchemaInheritance(unittest.TestCase):
                 id='a2',
                 )
             c = colander.SchemaNode(
-                colander.String(), 
+                colander.String(),
                 id='c2',
                 )
             e = colander.SchemaNode(
                 colander.String(),
                 id='e2',
                 )
-            
+
         class Three(Two):
             b = colander.SchemaNode(
                 colander.Bool(),
@@ -2801,14 +2825,14 @@ class TestMappingSchemaInheritance(unittest.TestCase):
                 id='a2',
                 )
             c = colander.SchemaNode(
-                colander.String(), 
+                colander.String(),
                 id='c2',
                 )
             e = colander.SchemaNode(
                 colander.String(),
                 id='e2',
                 )
-            
+
         class Three(Two, One):
             b = colander.SchemaNode(
                 colander.Bool(),

--- a/docs/null.rst
+++ b/docs/null.rst
@@ -357,5 +357,5 @@ When you use `colander.NoneType` you can pass the results of the deserialization
 without converting `colander.null` to None outside the schema. In other words, you have defined in the
 schema that the node can have None as value. 
 
-Note: NoneType can be used for strings, because the machinery does not known whether a serialization of `""` is 
-an empty string or a None.
+Note: NoneType can NOT be used for strings, because the machinery does not known whether a serialization of `""` is 
+an empty string or None.

--- a/docs/null.rst
+++ b/docs/null.rst
@@ -320,3 +320,42 @@ value_a               value_b               value_a used
    equivalent of ``mapping.get(keyname, colander.null)`` to find a subvalue
    during deserialization.
 
+
+The None Value
+==============
+
+Every colander SchemaType will only (de)serialize a value which belongs to its type.
+A `colander.Boolean` will always deserialized to `True` or `False` and never to a value
+of which is not a boolean.
+
+I some use cases, you need to have a schema which can also deserialize to `None`. For example
+in the previous schema in this chapter, you can add a `colander.NoneType`
+as a wrapper around `colander.Int` in order to deserialize an empty string to `None`.
+
+.. code-block:: python
+
+   import colander
+
+   class Person(colander.MappingSchema):
+       name = colander.SchemaNode(colander.String())
+       age = colander.SchemaNode(colander.NoneType(colander.Int()))
+
+   schema = Person()
+   deserialized = schema.deserialize({'name':'Fred', 'age': ''})
+   assert deserialized['age'] == None
+
+   deserialized = schema.deserialize({'name':'Fred', 'age': '19'})
+   assert deserialized['age'] == 19
+
+   serialized = schema.serialize({'name':'Fred', 'age': None})
+   assert serialized['age'] == ''
+
+   serialized = schema.serialize({'name':'Fred', 'age': 19})
+   assert serialized['age'] == '19'
+
+When you use `colander.NoneType` you can pass the results of the deserialization directly to a database,
+without converting `colander.null` to None outside the schema. In other words, you have defined in the
+schema that the node can have None as value. 
+
+Note: NoneType can be used for strings, because the machinery does not known whether a serialization of `""` is 
+an empty string or a None.


### PR DESCRIPTION
In my apps, I have Colander schemas with optional fields for which None is needed to store the absence of a value in ie a SQL database. For that, the colander.null value can not be used. So I made a supertype which can embrace every other schematype to add the posibility to add None as value.

Example:

typ = NoneType(Boolean())
serialize True --> 'true'
serialize None --> ''
deserialize '' --> None
deserlialize 'true' --> True