### PR TITLE
allow `typ` as a keyword arg to SchemaNode

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,9 @@ Features
       result = What().serialize({}) # no "thing" in mapping
       assert result == {}
 
+- The ``typ`` of a ``SchemaNode`` can optionally be pased in as a keyword
+  argument. See https://github.com/Pylons/colander/issues/90
+
 1.0a5 (2013-05-31)
 ------------------
 

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1716,6 +1716,9 @@ class _SchemaNode(object):
 
     - ``name``: The name of this node.
 
+    - ``typ``: The 'type' for this node can optionally be passed in as a
+      keyword argument. See the documentation for the positional arg above.
+
     - ``default``: The default serialization value for this node.
       Default: :attr:`colander.null`.
 
@@ -1788,7 +1791,10 @@ class _SchemaNode(object):
 
     def __init__(self, *arg, **kw):
         # bw compat forces us to treat first arg as type always
-        if arg:
+        if 'typ' in kw:
+            self.typ = kw.pop('typ')
+            _add_node_children(self, arg)
+        elif arg:
             self.typ = arg[0]
             _add_node_children(self, arg[1:])
         else:

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2303,6 +2303,16 @@ class TestSchemaNode(unittest.TestCase):
         node = self._makeOne(None, foo=1)
         self.assertEqual(node.foo, 1)
 
+    def test_ctor_with_kwarg_typ(self):
+        node = self._makeOne(typ='foo')
+        self.assertEqual(node.typ, 'foo')
+
+    def test_ctor_children_kwarg_typ(self):
+        subnode1 = DummySchemaNode(None, name='sub1')
+        subnode2 = DummySchemaNode(None, name='sub2')
+        node = self._makeOne(subnode1, subnode2, typ='foo')
+        self.assertEqual(node.children, [subnode1, subnode2])
+
     def test_ctor_without_type(self):
         self.assertRaises(NotImplementedError, self._makeOne)
 


### PR DESCRIPTION
fixes #90
