### PR TITLE
Add a MANIFEST.in file to guarantee installing translations.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include colander *.mo


### PR DESCRIPTION
Currently, the installation of package data relies on automatic guessing in setuptools which is quite fragile and sometimes results in incomplete installs. Instead, I suggest adding this one-line `MANIFEST.in` which will install translations independently of setuptools plugin existence and egg-info availability.

For more details, please take a look at https://github.com/malthe/chameleon/pull/151 where I explained a similar issue in another project.
