### PR TITLE
make it possible to clone parts of schemanode

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1708,7 +1708,7 @@ class _SchemaNode(object):
             _add_node_children(self, arg[1:])
         else:
             self.typ = self.schema_type()
-        
+
         # bw compat forces us to manufacture a title if one is not supplied
         title = kw.get('title', _marker)
         if title is _marker:
@@ -1861,13 +1861,17 @@ class _SchemaNode(object):
                 return node
         return default
 
-    def clone(self):
+    def clone(self, subnodes=None):
         """ Clone the schema node and return the clone.  All subnodes
         are also cloned recursively.  Attributes present in node
-        dictionaries are preserved."""
+        dictionaries are preserved.
+
+        `subnodes` can be given as argument and must contain a list of
+        strings. If present, only the subnodes with the given names
+        will be cloned"""
         cloned = self.__class__(self.typ)
         cloned.__dict__.update(self.__dict__)
-        cloned.children = [ node.clone() for node in self.children ]
+        cloned.children = [ node.clone() for node in self.children if subnodes is None or node.name in subnodes]
         return cloned
 
     def bind(self, **kw):
@@ -1999,7 +2003,7 @@ SchemaNode = _SchemaMeta(
     (_SchemaNode,),
     {}
     )
-    
+
 class Schema(SchemaNode):
     schema_type = Mapping
 

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -465,7 +465,7 @@ class Test_url_validator(unittest.TestCase):
         val = 'http://example.com'
         result = self._callFUT(val)
         self.assertEqual(result, None)
-        
+
     def test_it_failure(self):
         val = 'not-a-url'
         from colander import Invalid
@@ -727,7 +727,7 @@ class TestMapping(unittest.TestCase):
         node1.children = [node2]
         result = typ.cstruct_children(node1, null)
         self.assertEqual(result, [null])
-        
+
     def test_cstruct_children(self):
         from colander import null
         typ = self._makeOne()
@@ -959,7 +959,7 @@ class TestTuple(unittest.TestCase):
         node1.children = [node2]
         result = typ.cstruct_children(node1, null)
         self.assertEqual(result, [null])
-        
+
     def test_cstruct_children_toomany(self):
         typ = self._makeOne()
         node1 = DummySchemaNode(typ, name='node1')
@@ -1197,7 +1197,7 @@ class TestSequence(unittest.TestCase):
         typ = self._makeOne()
         result = typ.cstruct_children(None, null)
         self.assertEqual(result, SequenceItems([]))
-        
+
     def test_cstruct_children_cstruct_is_non_null(self):
         from colander import SequenceItems
         typ = self._makeOne()
@@ -2400,6 +2400,19 @@ class TestSchemaNode(unittest.TestCase):
         self.assertEqual(inner_clone.name, 'inner')
         self.assertEqual(inner_clone.foo, 2)
 
+    def test_clone_part(self):
+        import colander as c
+        class MySchema(c.MappingSchema):
+            number1 = c.SchemaNode(c.Int(), validator=c.Range(min=1))
+            number2 = c.SchemaNode(c.Int(), validator=c.Range(min=1))
+        mySchema = MySchema()
+        whole_clone = mySchema.clone()
+        part_clone = mySchema.clone(['number1'])
+
+        self.assertEqual(len(whole_clone.children), 2)
+        self.assertEqual(len(part_clone.children), 1)
+
+
     def test_bind(self):
         from colander import deferred
         inner_typ = DummyType()
@@ -2508,7 +2521,7 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
         node = MyNode(missing=5)
         result = node.deserialize(colander.null)
         self.assertEqual(result, 5)
-        
+
     def test_method_values_can_rely_on_binding(self):
         import colander
         class MyNode(colander.SchemaNode):
@@ -2751,14 +2764,14 @@ class TestMappingSchemaInheritance(unittest.TestCase):
                 id='a2',
                 )
             c = colander.SchemaNode(
-                colander.String(), 
+                colander.String(),
                 id='c2',
                 )
             e = colander.SchemaNode(
                 colander.String(),
                 id='e2',
                 )
-            
+
         class Three(Two):
             b = colander.SchemaNode(
                 colander.Bool(),
@@ -2801,14 +2814,14 @@ class TestMappingSchemaInheritance(unittest.TestCase):
                 id='a2',
                 )
             c = colander.SchemaNode(
-                colander.String(), 
+                colander.String(),
                 id='c2',
                 )
             e = colander.SchemaNode(
                 colander.String(),
                 id='e2',
                 )
-            
+
         class Three(Two, One):
             b = colander.SchemaNode(
                 colander.Bool(),


### PR DESCRIPTION
For some apps I want to use a complete schema as a base for derived schemas which are equal to the complete schema but only contains a subset of the subnodes. I have implemented that via adding an optional argument to `clone` which contains the names of the subnodes to clone.