### PR TITLE
Deserialize the empty string into the empty string instead of colander.null

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1123,7 +1123,7 @@ class String(SchemaType):
                             mapping={'val':appstruct, 'err':e})
                           )
     def deserialize(self, node, cstruct):
-        if not cstruct:
+        if cstruct != "" and not cstruct:
             return null
 
         try:

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -1347,8 +1347,9 @@ class TestString(unittest.TestCase):
         from colander import null
         node = DummySchemaNode(None)
         typ = self._makeOne(None)
-        result = typ.deserialize(node, '')
-        self.assertEqual(result, null)
+        val = ''
+        result = typ.deserialize(node, val)
+        self.assertEqual(result, val)
 
     def test_deserialize_uncooperative(self):
         val = Uncooperative()

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -127,7 +127,7 @@ return :attr:`colander.null` to its caller.
 
 A type might also choose to return :attr:`colander.null` if the value it
 receives is *logically* (but not literally) null.  For example,
-:class:`colander.String` type converts the empty string to ``colander.null``
+:class:`colander.Time` type converts the empty string to ``colander.null``
 within its ``deserialize`` method.
 
 .. code-block:: python


### PR DESCRIPTION
If you were previously relying on the old behavior, where if the value is present, but empty it was treated as missing (such as in some web forms), it may be necessary to add a Length validator.
    
```python
>>> foo = colander.SchemaNode(colander.String(), validator=colander.Length(min=1))
>>> foo.deserialize("")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "colander/__init__.py", line 1943, in deserialize
    self.validator(self, appstruct)
  File "colander/__init__.py", line 365, in __call__
    raise Invalid(node, min_err)
colander.Invalid: {'': u'Shorter than minimum length 1'}
```