### PR TITLE
Use Mapping as a default SchemaNode typ.

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1843,10 +1843,7 @@ class _SchemaNode(object):
 
     @staticmethod
     def schema_type():
-        raise NotImplementedError(
-            'Schema node construction without a typ argument or '
-            'a schema_type() callable present on the node class '
-            )
+        return Mapping
 
     @property
     def required(self):


### PR DESCRIPTION
Typ of the Node should have a reasonable default, just like the documentation for `_SchemaNode` suggests.