### PR TITLE
Now implicitly assign the schema type to MappingSchema, SequenceSchema, ...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,11 @@ Bug Fixes
 - Fix an issue where ``drop`` was not recognized as a default and was
   returning the ``drop`` instance instead of omitting the value.
   https://github.com/Pylons/colander/issues/139
+- We implicitly assign the schema type to MappingSchema, SequenceSchema, and
+  TupleSchema with types of Mapping, Sequence, and Tuple explicitly.  This is
+  a minor backwards incompatibility, because we no longer allow any of those
+  schema variants to accept the implied type as a first argument.  
+  i.e. MappingSchema(Mapping()) will no longer work.
 
 Features
 ~~~~~~~~

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -115,3 +115,4 @@ Contributors
 - Peter Lamut, 2013/08/16
 - Veeti Paananen, 2013/08/20
 - Michael Howitz, 2013/12/05
+- Joe Dallago, 2014/2/10

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -2127,16 +2127,22 @@ SchemaNode = _SchemaMeta(
 class Schema(SchemaNode):
     schema_type = Mapping
 
+    def __init__(self, *args, **kw):
+        SchemaNode.__init__(self, Mapping(), *args, **kw)
+
 MappingSchema = Schema
 
 class TupleSchema(SchemaNode):
     schema_type = Tuple
 
+    def __init__(self, *args, **kw):
+        SchemaNode.__init__(self, Tuple(), *args, **kw)
+
 class SequenceSchema(SchemaNode):
     schema_type = Sequence
 
     def __init__(self, *args, **kw):
-        SchemaNode.__init__(self, *args, **kw)
+        SchemaNode.__init__(self, Sequence(), *args, **kw)
         if len(self.children) != 1:
             raise Invalid(self,
                           'Sequence schemas must have exactly one child node')

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -3163,6 +3163,13 @@ class TestSchema(unittest.TestCase):
         result = node.serialize(expected)
         self.assertEqual(result, expected)
 
+    def test_imperative_with_implicit_schema_type(self):
+        import colander
+        node = colander.SchemaNode(colander.String())
+        schema = colander.Schema(node)
+        self.assertEqual(schema.schema_type, colander.Mapping)
+        self.assertEqual(schema.children[0], node)
+
 class TestSequenceSchema(unittest.TestCase):
     def test_succeed(self):
         import colander
@@ -3196,6 +3203,13 @@ class TestSequenceSchema(unittest.TestCase):
             e.msg,
             'Sequence schemas must have exactly one child node')
 
+    def test_imperative_with_implicit_schema_type(self):
+        import colander
+        node = colander.SchemaNode(colander.String())
+        schema = colander.SequenceSchema(node)
+        self.assertEqual(schema.schema_type, colander.Sequence)
+        self.assertEqual(schema.children[0], node)
+
 class TestTupleSchema(unittest.TestCase):
     def test_it(self):
         import colander
@@ -3206,6 +3220,13 @@ class TestTupleSchema(unittest.TestCase):
         self.assertTrue(isinstance(node, colander.SchemaNode))
         self.assertEqual(node.typ.__class__, colander.Tuple)
         self.assertEqual(node.children[0].typ.__class__, colander.String)
+
+    def test_imperative_with_implicit_schema_type(self):
+        import colander
+        node = colander.SchemaNode(colander.String())
+        schema = colander.TupleSchema(node)
+        self.assertEqual(schema.schema_type, colander.Tuple)
+        self.assertEqual(schema.children[0], node)
 
 class TestFunctional(object):
     def test_deserialize_ok(self):


### PR DESCRIPTION
...and TupleSchema, using Mapping, Sequence, and Tuple respectively.