### PR TITLE
Fix docstring being inconsistent with behavior

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1887,6 +1887,8 @@ class _SchemaNode(object):
         if isinstance(appstruct, deferred): # unbound schema with deferreds
             appstruct = null
         cstruct = self.typ.serialize(self, appstruct)
+        if self.missing is drop and cstruct is null:
+            cstuct = drop
         return cstruct
 
     def flatten(self, appstruct):


### PR DESCRIPTION
The docstring for missing in _SchemaNode says:

> When `missing` is `colander.drop`, the node is dropped from the schema if it isn't set during serialization/deserialization.

In reality it is only dropped on deserialization.
The attached commit changes the return value of `_SchemaNode.serialize` to `colander.drop` if `_SchemaNode.missing` is `colander.drop` and the cstruct return from the type serialization method is `colander.null`.

I may have misinterpreted the docstring. If that is the case, I think it could be made slightly clearer.