### PR TITLE
Include the right CHANGES file in documentation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,1 +1,1 @@
-.. include:: ../CHANGES.txt
+.. include:: ../CHANGES.rst


### PR DESCRIPTION
Currently Sphinx will fail to build because ../CHANGES.txt is included instead of ../CHANGES.rst. This commit fixes the issue.
