### PR TITLE
make version PEP440 compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ testing_extras = ['nose', 'coverage']
 docs_extras = ['Sphinx']
 
 setup(name='colander',
-      version='1.1dev',
+      version='1.1.dev0',
       description=('A simple schema-based serialization and deserialization '
                    'library'),
       long_description=README + '\n\n' +  CHANGES,


### PR DESCRIPTION
changes to setuptools is causing warnings to non-PEP440 compliant version strings