### PR TITLE
Error cloning SequenceSchema

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -125,3 +125,4 @@ Contributors
 - Nando Florestan, 2014/11/27
 - Amos Latteier, 2014/11/30
 - Jimmy Thrasibule, 2014/12/11
+- Hugo Branquinho, 2015/01/21

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -2042,9 +2042,12 @@ class _SchemaNode(object):
         """ Clone the schema node and return the clone.  All subnodes
         are also cloned recursively.  Attributes present in node
         dictionaries are preserved."""
-        cloned = self.__class__(self.typ)
-        cloned.__dict__.update(self.__dict__)
-        cloned.children = [ node.clone() for node in self.children ]
+        children = [node.clone() for node in self.children]
+        cloned = self.__class__(self.typ, *children)
+
+        attributes = self.__dict__.copy()
+        attributes.pop('children', None)
+        cloned.__dict__.update(attributes)
         return cloned
 
     def bind(self, **kw):

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -3319,6 +3319,13 @@ class TestSequenceSchema(unittest.TestCase):
             e.msg,
             'Sequence schemas must have exactly one child node')
 
+    def test_clone(self):
+        import colander
+        thingnode = colander.SchemaNode(colander.String())
+        thingnode2 = colander.SchemaNode(colander.String())
+        schema = colander.SequenceSchema(colander.Sequence(), thingnode, thingnode2)
+        schema.clone()
+
 class TestTupleSchema(unittest.TestCase):
     def test_it(self):
         import colander


### PR DESCRIPTION
I'm not sure if this is the best way, but here goes.

When we try to clone a SequenceSchema like this
```python
class Persons(SequenceSchema):
    name = SchemaNode(String())
print Persons().clone()
```
or 
```python
Persons = SchemaNode(Sequence(), SchemaNode(String(), name='name'))
print Persons.clone()
```
Everything goes ok, but if we do like this
```python
Persons = SequenceSchema(Sequence(), SchemaNode(String(), name='name'))
print Persons.clone()
```
We have "Sequence schemas must have exactly one child node".