### PR TITLE
Do not deserialize empty strings as null (fixes #214)

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1186,7 +1186,7 @@ class String(SchemaType):
                             mapping={'val':appstruct, 'err':e})
                           )
     def deserialize(self, node, cstruct):
-        if not cstruct:
+        if not cstruct and cstruct != '':
             return null
 
         try:

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -1448,11 +1448,24 @@ class TestString(unittest.TestCase):
         from colander import String
         self.assertEqual(Str, String)
 
-    def test_deserialize_emptystring(self):
-        from colander import null
+    def test_deserialize_empty_string(self):
         node = DummySchemaNode(None)
         typ = self._makeOne(None)
         result = typ.deserialize(node, '')
+        self.assertEqual(result, '')
+
+    def test_deserialize_null(self):
+        from colander import null
+        node = DummySchemaNode(None)
+        typ = self._makeOne(None)
+        result = typ.deserialize(node, null)
+        self.assertEqual(result, null)
+
+    def test_deserialize_none(self):
+        from colander import null
+        node = DummySchemaNode(None)
+        typ = self._makeOne(None)
+        result = typ.deserialize(node, None)
         self.assertEqual(result, null)
 
     def test_deserialize_uncooperative(self):


### PR DESCRIPTION
This PR is a proposal to fix #214.

As stated there, currently it is not possible to deserialize empty strings as such.

They were considered ``colander.null``.

