### PR TITLE
unify `required`, `null`, and `drop`

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -22,7 +22,12 @@ from . import iso8601
 
 _ = translationstring.TranslationStringFactory('colander')
 
-required = object()
+class _required(object):
+    """ Represents a required value in colander-related operations. """
+    def __repr__(self):
+        return '<colander.required>'
+
+required = _required()
 _marker = required # bw compat
 
 class _null(object):
@@ -46,7 +51,8 @@ class _drop(object):
     Represents a value that should be dropped if it is missing during
     deserialization.
     """
-    pass
+    def __repr__(self):
+        return '<colander.drop>'
 
 drop = _drop()
 

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -3783,6 +3783,16 @@ class Test_null(unittest.TestCase):
         import pickle
         self.assertTrue(pickle.loads(pickle.dumps(null)) is null)
 
+class Test_required(unittest.TestCase):
+    def test___repr__(self):
+        from colander import required
+        self.assertEqual(repr(required), '<colander.required>')
+
+class Test_drop(unittest.TestCase):
+    def test___repr__(self):
+        from colander import drop
+        self.assertEqual(repr(drop), '<colander.drop>')
+
 class Dummy(object):
     pass
 


### PR DESCRIPTION
When I was trying to introspect schemas I printed out "missing: \<object object at 0x7fa8787da240>", "missing: \<colander.null>" and "missing: \<colander._drop object at 0x7fa8737e4978>".  The first is supposed to be a colander.required but unfortunately it's just a generic object placeholder.  This PR is to unify colander.required, colander.drop and colander.null.