### PR TITLE
Revert "Update __init__.py"

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1893,7 +1893,7 @@ class _SchemaNode(object):
     @staticmethod
     def schema_type():
         raise NotImplementedError(
-            'Schema node construction without a type argument or '
+            'Schema node construction without a typ argument or '
             'a schema_type() callable present on the node class '
             )
 

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1893,7 +1893,7 @@ class _SchemaNode(object):
     @staticmethod
     def schema_type():
         raise NotImplementedError(
-            'Schema node construction without a typ argument or '
+            'Schema node construction without a `typ` argument or '
             'a schema_type() callable present on the node class '
             )
 


### PR DESCRIPTION
Reverts Pylons/colander#207

`typ` is not a typo.  That's the actual argument name you pass to the class (for better or worse).