### PR TITLE
make default UTC directly

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1577,9 +1577,7 @@ class DateTime(SchemaType):
     """
     err_template =  _('Invalid date')
 
-    def __init__(self, default_tzinfo=_marker):
-        if default_tzinfo is _marker:
-            default_tzinfo = iso8601.Utc()
+    def __init__(self, default_tzinfo=iso8601.UTC):
         self.default_tzinfo = default_tzinfo
 
     def serialize(self, node, appstruct):


### PR DESCRIPTION
The current docs show
`colander.DateTime(default_tzinfo=<object object at 0x7fef11f71aa0>)`
due to using the `_marker`.  `iso8601` has a `UTC` object that is
an already instatiated version of `iso8601.Utc()` and outputs its
repr as "\<iso8601.Utc>".  This should change the docs to print out:
`colander.DateTime(default_tzinfo=<iso8601.Utc>)`.