### PR TITLE
remove duplication of documentation

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -47,9 +47,9 @@ class _null(object):
 null = _null()
 
 class _drop(object):
-    """
-    Represents a value that should be dropped if it is missing during
-    deserialization.
+    """ Represents a value that will be dropped from the schema if it
+    is missing during *deserialization*.  Passed as a value to the
+    `missing` keyword argument of :class:`SchemaNode`.
     """
     def __repr__(self):
         return '<colander.drop>'

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -147,16 +147,12 @@ Schema-Related
 
   .. autoclass:: instantiate
 
-  .. attribute:: null
+  .. autodata:: null
+     :annotation:
 
-     Represents a null value in colander-related operations.
+  .. autodata:: required
+     :annotation:
 
-  .. attribute:: required
+  .. autodata:: drop
+     :annotation:
 
-     Represents a required value in colander-related operations.
-
-  .. attribute:: drop
-
-     Represents a value that will be dropped from the schema if it is missing
-     during *deserialization*.  Passed as a value to the `missing` keyword
-     argument of :class:`SchemaNode`.


### PR DESCRIPTION
I updated the docstring to equal what was in the api.rst and then made it display the docstring.  The end result in the html is the same, but now there's only a single copy of the docs and it's in the source code.