### PR TITLE
add `drop` support to `Sequence`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Features
 - Add a ``missing_msg`` argument to ``SchemaNode`` that specifies the error
   message to be used when the node is required and missing
 
+- Add ``drop`` functionality to ``Sequence`` type.
+
 Bug Fixes
 ---------
 

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -988,12 +988,18 @@ class Sequence(Positional, SchemaType):
         result = []
 
         for num, subval in enumerate(value):
+            if subval is drop or (subval is null and subnode.default is drop):
+                continue
             try:
-                result.append(callback(node.children[0], subval))
+                sub_result = callback(node.children[0], subval)
             except Invalid as e:
                 if error is None:
                     error = Invalid(node)
                 error.add(e, num)
+            else:
+                if sub_result is drop:
+                    continue
+                result.append(sub_result)
 
         if error is not None:
             raise error

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -987,11 +987,12 @@ class Sequence(Positional, SchemaType):
         error = None
         result = []
 
+        subnode = node.children[0]
         for num, subval in enumerate(value):
             if subval is drop or (subval is null and subnode.default is drop):
                 continue
             try:
-                sub_result = callback(node.children[0], subval)
+                sub_result = callback(subnode, subval)
             except Invalid as e:
                 if error is None:
                     error = Invalid(node)

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -1320,6 +1320,14 @@ class TestSequence(unittest.TestCase):
         result = typ.serialize(node, colander.null)
         self.assertEqual(result, colander.null)
 
+    def test_serialize_drop(self):
+        from colander import drop
+        node = DummySchemaNode(None)
+        node.children = [DummySchemaNode(None, name='a')]
+        typ = self._makeOne()
+        result = typ.serialize(node, (drop,))
+        self.assertEqual(result, [])
+
     def test_serialize_not_iterable(self):
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -3318,6 +3326,24 @@ class TestSequenceSchema(unittest.TestCase):
         self.assertEqual(
             e.msg,
             'Sequence schemas must have exactly one child node')
+
+    def test_deserialize_drop(self):
+        import colander
+        class MySchema(colander.SequenceSchema):
+            a = colander.SchemaNode(colander.String(), missing=colander.drop)
+        node = MySchema()
+        result = node.deserialize([None])
+        self.assertEqual(result, [])
+        result = node.deserialize([colander.null])
+        self.assertEqual(result, [])
+
+    def test_serialize_drop_default(self):
+        import colander
+        class MySchema(colander.SequenceSchema):
+            a = colander.SchemaNode(colander.String(), default=colander.drop)
+        node = MySchema()
+        result = node.serialize([colander.null])
+        self.assertEqual(result, [])
 
 class TestTupleSchema(unittest.TestCase):
     def test_it(self):


### PR DESCRIPTION
To deal with #224.  Sequence/SequenceSchema now supports `null` and `drop` in the same way Mapping does.