### PR TITLE
Update docs regarding `typ` argument to SchemaNode

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1785,7 +1785,9 @@ class _SchemaNode(object):
     - ``typ``: The 'type' for this node.  It should be an
       instance of a class that implements the
       :class:`colander.interfaces.Type` interface.  If ``typ`` is not passed,
-      it defaults to ``colander.Mapping()``.
+      a call to the ``schema_type()`` method on this class is made to
+      get a default type.  (When subclassing, ``schema_type()`` should
+      be overridden to provide a reasonable default type).
 
     - ``*children``: a sequence of subnodes.  If the subnodes of this
       node are not known at construction time, they can later be added


### PR DESCRIPTION
solves #230 

Judging from comments on #162 it seems like we shouldn't be defaulting a `typ` on SchemaNode as people should be using a subclassed version with `schema_type()` defined instead.

A test case is already in place at `TestSchemaNode.test_ctor_without_type`.