### PR TITLE
fix #231; add sphinx doctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - TOXENV=pypy
   - TOXENV=pypy3
   - TOXENV=cover
+  - TOXENV=docs
 
 install:
   - travis_retry pip install tox

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -1,5 +1,9 @@
 .. _basics:
 
+.. testsetup::
+
+     import colander
+
 Colander Basics
 ===============
 
@@ -168,10 +172,10 @@ behavior.  The subclass can define the following methods and attributes:
 
 The imperative style that looks like this still works, of course:
 
-.. code-block:: python
+.. testcode::
 
      ranged_int = colander.SchemaNode(
-         schema_type=colander.Int,
+         typ=colander.Int(),
          validator=colander.Range(0, 10),
          default=10,
          title='Ranged Int'
@@ -179,7 +183,7 @@ The imperative style that looks like this still works, of course:
 
 But in 1.0a1+, you can alternately now do something like this:
 
-.. code-block:: python
+.. testcode::
 
      class RangedInt(colander.SchemaNode):
          schema_type = colander.Int
@@ -192,7 +196,7 @@ But in 1.0a1+, you can alternately now do something like this:
 Values that are expected to be callables can now alternately be methods of
 the schemanode subclass instead of plain attributes:
 
-.. code-block:: python
+.. testcode::
 
      class RangedInt(colander.SchemaNode):
          schema_type = colander.Int

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ import pylons_sphinx_themes
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['.templates']

--- a/tox.ini
+++ b/tox.ini
@@ -23,3 +23,4 @@ basepython =
 commands =
     pip install colander[docs]
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+    sphinx-build -b doctest docs docs/_build/doctest


### PR DESCRIPTION
To try to prevent further issues in the future, I've added `sphinx.ext.doctest` and added running the doctests in tox.  Right now it only tests 3 blocks, but I wanted to make sure this kind of thing was acceptable before expanding it to other code blocks.

The only drawback I've found with `doctest` so far is that you don't have the same options with `.. testcode` as you do with `.. code-block`.  For example, you can't add line numbers with `:lineno:` in a `.. testcode`.  I think the benefit with `doctest` outweighs that drawback in most cases, though.