### PR TITLE
issue with `title` being overwritten when child

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Bug Fixes
 - Fixed issue with ``String`` not being properly encoded when non-string
   values were passed into ``serialize()``
   See `#235 <https://github.com/Pylons/colander/pull/235>`_
+- ``title`` was being overwritten when made a child through defining a schema
+  as a class.  See `#239 <https://github.com/Pylons/colander/pull/239>`_
 
 
 1.0 (2014-11-26)

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1862,7 +1862,7 @@ class _SchemaNode(object):
     missing = required
     missing_msg = 'Required'
     name = ''
-    raw_title = _marker
+    raw_title = _marker  # only changes if title is explicitly set
     title = _marker
     description = ''
     widget = None
@@ -1888,11 +1888,10 @@ class _SchemaNode(object):
             self.typ = self.schema_type()
 
         # bw compat forces us to manufacture a title if one is not supplied
-        title = kw.get('title', _marker)
+        title = kw.get('title', self.title)
         if title is _marker:
-            if self.title is _marker:
-                name = kw.get('name', self.name)
-                kw['title'] = name.replace('_', ' ').title()
+            name = kw.get('name', self.name)
+            kw['title'] = name.replace('_', ' ').title()
         else:
             kw['raw_title'] = title
 

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2847,6 +2847,16 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
         node = MyNode(name='my', title='other title')
         self.assertEqual(node.title, 'other title')
 
+    def test_subelement_title_not_overwritten(self):
+        import colander
+        class SampleNode(colander.SchemaNode):
+            schema_type = colander.String
+            title = 'Some Title'
+        class SampleSchema(colander.Schema):
+            node = SampleNode()
+        schema = SampleSchema()
+        self.assertEqual('Some Title', schema.children[0].title)
+
     def test_subclass_value_overridden_by_constructor(self):
         import colander
         class MyNode(colander.SchemaNode):


### PR DESCRIPTION
PR #183 and #185 tried to fix this but missed one aspect when
a schemanode is added as a child via class definitions.

This is related to http://stackoverflow.com/questions/23135499/colander-subclassing-schemanode/31212539

The funny thing is the example given in #183 didn't work so I used that as the test case.  ^_^