### PR TITLE
Add note about deprecated parameter in docstring

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -282,6 +282,8 @@ class Function(object):
 
     The default value for the ``msg`` when not provided via the
     constructor is ``Invalid value``.
+
+    The ``message`` parameter has been deprecated, use ``msg`` instead.
     """
     def __init__(self, function, msg=None, message=None):
         self.function = function


### PR DESCRIPTION
Looking at the documentation, I could not understand which parameter I should use between `msg` and `message`. I had to look at the code to understand.

https://github.com/Pylons/colander/blob/2b8cdb330144f932825bdc9be1500e276a3d047a/colander/__init__.py#L293-L299

I'm adding a note to clarify the documentation.