### PR TITLE
Add MANIFEST.in to ensure locales are in downstream packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft colander/locale

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 graft colander/locale
+include *.rst LICENSE.txt COPYRIGHT.txt CONTRIBUTORS.txt


### PR DESCRIPTION
Currently debian package does not content locales information (.po/.mo) files,

it can be fix in upstream package like that.

