### PR TITLE
Drop building the epub docset as part of the default 'docs' environ.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,14 @@ basepython = python3.5
 whitelist_externals = make
 commands =
     pip install colander[docs]
-    make -C docs html epub BUILDDIR={envdir} "SPHINXOPTS=-W -E"
+    make -C docs html BUILDDIR={envdir} "SPHINXOPTS=-W -E"
+
+[testenv:docs-epub]
+basepython = python3.5
+whitelist_externals = make
+commands =
+    pip install colander[docs]
+    make -C docs epub BUILDDIR={envdir} "SPHINXOPTS=-W -E"
 
 # we separate coverage into its own testenv because a) "last run wins" wrt
 # cobertura jenkins reporting and b) pypy and jython can't handle any


### PR DESCRIPTION
It generates warnings for unknown mimetypes, which end up failing the build.

```
sphinx-build -b epub -d _build/doctrees  -W -E . _build/epub
Running Sphinx v1.4.6
building [mo]: targets for 0 po files that are out of date
building [epub]: targets for 10 source files that are out of date
updating environment: 10 added, 0 changed, 0 removed
reading sources... [ 10%] api
reading sources... [ 20%] basics
reading sources... [ 30%] binding
reading sources... [ 40%] changes
reading sources... [ 50%] extending
reading sources... [ 60%] glossary
reading sources... [ 70%] index
reading sources... [ 80%] interfaces
reading sources... [ 90%] manipulation
reading sources... [100%] null_and_drop

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [ 10%] api
writing output... [ 20%] basics
writing output... [ 30%] binding
writing output... [ 40%] changes
writing output... [ 50%] extending
writing output... [ 60%] glossary
writing output... [ 70%] index
writing output... [ 80%] interfaces
writing output... [ 90%] manipulation
writing output... [100%] null_and_drop

generating indices... genindex py-modindex
writing additional pages...
copying static files... done
copying extra files... done
writing mimetype file...
writing META-INF/container.xml file...
writing content.opf file...

Warning, treated as error:
WARNING: unknown mimetype for extending.html, ignoring
```