### PR TITLE
Fix SchemaNode.clone regression.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.3.2 (unreleased)
+==================
+
+- Fixed a regression that was introduced in 1.3 causing ``SchemaNode.clone`` to
+  to return a clone with non matching children when the cloned instance's
+  children were modified after instantiation.
+  See https://github.com/Pylons/colander/pull/272
+
 1.3.1 (2016-05-23)
 ==================
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -137,3 +137,4 @@ Contributors
 - Steve Piercy, 2016/02/26
 - Sergiu Bivol, 2016/04/23
 - Denis Nasyrov, 2016/08/23
+- Andreas Kaiser, 2016/09/16

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -2120,6 +2120,8 @@ class _SchemaNode(object):
         dictionaries are preserved."""
         children = [node.clone() for node in self.children]
         cloned = self.__class__(self.typ, *children)
+        cloned.children = []
+        _add_node_children(cloned, children)
 
         attributes = self.__dict__.copy()
         attributes.pop('children', None)

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -2120,6 +2120,10 @@ class _SchemaNode(object):
         dictionaries are preserved."""
         children = [node.clone() for node in self.children]
         cloned = self.__class__(self.typ, *children)
+        # Children must be reset and added again to prevent "faulty" children
+        # on the clone when the instance's children were modified before
+        # cloning (for example an item was deleted from children or the
+        # children were reordered, see #272 for details).
         cloned.children = []
         _add_node_children(cloned, children)
 

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2787,6 +2787,32 @@ class TestSchemaNode(unittest.TestCase):
         self.assertEqual(inner_clone.name, 'inner')
         self.assertEqual(inner_clone.foo, 2)
 
+    def test_clone_with_modified_schema_instance(self):
+        import colander
+        class Schema(colander.MappingSchema):
+            n1 = colander.SchemaNode(colander.String())
+            n2 = colander.SchemaNode(colander.String())
+        def compare_children(schema, cloned):
+            # children of the clone must match the cloned node's children and
+            # have to be clones themselves.
+            for child, child_clone in zip(schema.children, cloned.children):
+                self.assertIsNot(child, child_clone)
+                for name in child.__dict__.keys():
+                    self.assertEqual(getattr(child, name),
+                                     getattr(child_clone, name))
+        # add a child node before cloning
+        schema = Schema()
+        schema.add(colander.SchemaNode(colander.String(), name='n3'))
+        compare_children(schema, schema.clone())
+        # remove a child node before cloning
+        schema = Schema()
+        del schema['n1']
+        compare_children(schema, schema.clone())
+        # reorder children before cloning
+        schema = Schema()
+        schema.children = list(reversed(schema.children))
+        compare_children(schema, schema.clone())
+
     def test_bind(self):
         from colander import deferred
         inner_typ = DummyType()


### PR DESCRIPTION
The change to ``SchemaNode.clone`` in b5d42077fa8bb3bc9c6745a9357ad47ce977e690 / https://github.com/Pylons/colander/pull/212 introduced a regression that produces faulty children on the clone when the instance's children were modified before cloning (for example an item was deleted from children or the children were reordered). This PR reverts the regression while still passing the tests that were added with https://github.com/Pylons/colander/pull/212.