### PR TITLE
Add support for deferred schema nodes

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -137,3 +137,4 @@ Contributors
 - Steve Piercy, 2016/02/26
 - Sergiu Bivol, 2016/04/23
 - Denis Nasyrov, 2016/08/23
+- Gabriela Surita, 2017/01/31

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -2145,7 +2145,10 @@ class _SchemaNode(object):
             v = getattr(self, k)
             if isinstance(v, deferred):
                 v = v(self, kw)
-                setattr(self, k, v)
+                if isinstance(v, SchemaNode):
+                    self[k] = v
+                else:
+                    setattr(self, k, v)
         if getattr(self, 'after_bind', None):
             self.after_bind(self, kw)
 

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -3008,6 +3008,17 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
         bound_node = node.bind()
         self.assertEqual(bound_node.deserialize(colander.null), 10)
 
+    def test_nodes_can_be_deffered(self):
+        import colander
+        class MySchema(colander.MappingSchema):
+            @colander.deferred
+            def child(node, kw):
+                return colander.SchemaNode(colander.String(), missing='foo')
+
+        node = MySchema()
+        bound_node = node.bind()
+        self.assertEqual(bound_node.deserialize({}), {'child': 'foo'})
+
     def test_schema_child_names_conflict_with_value_names_notused(self):
         import colander
         class MyNode(colander.SchemaNode):


### PR DESCRIPTION
This allows setting child nodes during binding as on the example:

```python
class MySchema(colander.MappingSchema):
    @colander.deferred
    def child(node, kw):
        return kw.get('child')

# Define the schema with an integer child
MySchema().bind(child=colander.SchemaNode(colander.Integer()))

# Define the schema with a string child
MySchema().bind(child=colander.SchemaNode(colander.String()))
```
The use case for this is where you have a complex nested schema with a small mutable part and you want to update this small part without having to declare another schema.