### PR TITLE
GlobalObject patched serialization

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -9,6 +9,7 @@ import pprint
 import re
 import translationstring
 import warnings
+import types
 
 from .compat import (
     text_,
@@ -1578,7 +1579,11 @@ class GlobalObject(SchemaType):
             return null
 
         try:
-            return appstruct.__name__
+            if isinstance(appstruct, types.ModuleType):
+                return appstruct.__name__
+            else:
+                return '{0.__module__}.{0.__name__}'.format(appstruct)
+            
         except AttributeError:
             raise Invalid(node,
                           _('"${val}" has no __name__',

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2095,6 +2095,12 @@ class TestGlobalObject(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.serialize(node, colander.tests)
         self.assertEqual(result, 'colander.tests')
+        
+        from colander import tests
+        typ = self._makeOne()
+        node = DummySchemaNode(None)
+        result = typ.serialize(node, tests)
+        self.assertEqual(result, 'colander.tests')
 
     def test_serialize_class(self):
         cls = self.__class__

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2096,6 +2096,43 @@ class TestGlobalObject(unittest.TestCase):
         result = typ.serialize(node, colander.tests)
         self.assertEqual(result, 'colander.tests')
 
+    def test_serialize_class(self):
+        cls = self.__class__
+        typ = self._makeOne()
+        node = DummySchemaNode(None)
+        result = typ.serialize(node, cls)
+        self.assertEqual(result, 'colander.tests.test_colander.TestGlobalObject')
+
+    def test_deserialize_class_ok(self):
+        import colander
+        names = (
+                 'colander.tests.test_colander.TestGlobalObject',
+                 '.tests.test_colander.TestGlobalObject',
+                 )
+        typ = self._makeOne(colander)
+        node = DummySchemaNode(None)
+        for name in names:
+            result = typ.deserialize(node, name)
+            self.assertEqual(result, self.__class__)
+
+        names = ('.TestGlobalObject',)
+        typ = self._makeOne(colander.tests.test_colander)
+        node = DummySchemaNode(None)
+        for name in names:
+            result = typ.deserialize(node, name)
+            self.assertEqual(result, self.__class__)         
+
+    def test_deserialize_class_fail(self):
+        import colander
+        names = ('.test_colander.TestGlobalObject',
+                 '.TestGlobalObject')
+        typ = self._makeOne(colander)
+        node = DummySchemaNode(None)
+        for name in names:
+           e = invalid_exc(typ.deserialize, node, name)
+           self.assertEqual(e.msg.interpolate(),
+                            'The dotted name "{0}" cannot be imported'.format(name))
+           
     def test_serialize_fail(self):
         typ = self._makeOne()
         node = DummySchemaNode(None)


### PR DESCRIPTION
Fixes #287 

GlobalObjects can now serialize classes as well as modules into absolute import paths.