### PR TITLE
Fix iso8601 upgrade

### DIFF
--- a/colander/iso8601.py
+++ b/colander/iso8601.py
@@ -1,5 +1,75 @@
 from __future__ import absolute_import
+
+from datetime import timedelta, tzinfo
 import iso8601
-from iso8601.iso8601 import (parse_date, ParseError, Utc, FixedOffset, UTC, ZERO, ISO8601_REGEX)
+from iso8601.iso8601 import (ParseError, FixedOffset, UTC, ISO8601_REGEX)
+
+try:
+    from iso8601.iso8601 import Utc, ZERO, parse_date
+except ImportError:
+    from iso8601.iso8601 import parse_date as iso8601_parse_date
+    # Yoinked from python docs
+    ZERO = timedelta(0)
+
+    class Utc(tzinfo):
+        """UTC Timezone
+
+        """
+        def utcoffset(self, dt):
+            return ZERO
+
+        def tzname(self, dt):
+            return "UTC"
+
+        def dst(self, dt):
+            return ZERO
+
+        def __repr__(self):
+            return "<iso8601.Utc>"
+
+    UTC = Utc()
+    iso8601.iso8601.UTC = UTC
+
+    def parse_date(datestring, default_timezone=UTC):
+        return iso8601_parse_date(
+            datestring,
+            default_timezone=default_timezone)
+
+    class FixedOffset(tzinfo):
+        """Fixed offset in hours and minutes from UTC
+
+        """
+        def __init__(self, offset_hours, offset_minutes, name):
+            self.__offset_hours = offset_hours  # Keep for later __getinitargs__
+            self.__offset_minutes = offset_minutes  # Keep for later __getinitargs__
+            self.__offset = timedelta(hours=offset_hours, minutes=offset_minutes)
+            self.__name = name
+
+        def __eq__(self, other):
+            if isinstance(other, FixedOffset):
+                return (
+                    (other.__offset == self.__offset)
+                    and
+                    (other.__name == self.__name)
+                )
+            if isinstance(other, tzinfo):
+                return other == self
+            return False
+
+        def __getinitargs__(self):
+            return (self.__offset_hours, self.__offset_minutes, self.__name)
+
+        def utcoffset(self, dt):
+            return self.__offset
+
+        def tzname(self, dt):
+            return self.__name
+
+        def dst(self, dt):
+            return ZERO
+
+        def __repr__(self):
+            return "<FixedOffset %r %r>" % (self.__name, self.__offset)
+
 
 __all__ = ["parse_date", "ParseError", "Utc", "FixedOffset"]

--- a/colander/iso8601.py
+++ b/colander/iso8601.py
@@ -52,9 +52,7 @@ except ImportError:
                     and
                     (other.__name == self.__name)
                 )
-            if isinstance(other, tzinfo):
-                return other == self
-            return False
+            return NotImplemented
 
         def __getinitargs__(self):
             return (self.__offset_hours, self.__offset_minutes, self.__name)

--- a/colander/tests/test_iso8601.py
+++ b/colander/tests/test_iso8601.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 import datetime
 
@@ -68,6 +69,11 @@ class Test_FixedOffset(unittest.TestCase):
                             datetime.timedelta(hours=1, minutes=30))
             self.assertEqual(inst2.tzname(None), 'oneandahalf')
             self.assertEqual(inst2.dst(None), ZERO)
+
+    def test__eq(self):
+        self.assertEqual(
+            NotImplemented,
+            self._makeOne().__eq__(datetime.tzinfo()))
 
     def test___repr__(self):
         inst = self._makeOne()

--- a/colander/tests/test_iso8601.py
+++ b/colander/tests/test_iso8601.py
@@ -33,6 +33,10 @@ class Test_Utc(unittest.TestCase):
             self.assertEqual(inst2.tzname(None), 'UTC')
             self.assertEqual(inst2.dst(None), ZERO)
 
+    def test__repr(self):
+        from ..iso8601 import Utc
+        self.assertEqual(Utc().__repr__(), '<iso8601.Utc>')
+
 class Test_FixedOffset(unittest.TestCase):
     def _makeOne(self):
         from ..iso8601 import FixedOffset


### PR DESCRIPTION
Fix for #294 

A copy of the code previously in `iso8601` behind try-except for `ImportError`. For tests to pass, `parse_date` and `iso8601.iso8601.UTC` needs to be patched. 

It's an ugly solution. Let me know how to improve or maybe preferred solution would be to version pin  `iso8601` lib to `0.1.11`.