### PR TITLE
Add a MANIFEST.in file so the locale folder gets included.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include colander/locale *


### PR DESCRIPTION
I noticed that Fedora's colander package did not include the locale
folder[0]. The package simply runs setup.py build and setup.py
install. By adding this MANIFEST.in file, the locale now gets
included with the installed package.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1527683

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>