### PR TITLE
Copy the mapping values when serializing.

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+import copy
 import datetime
 import decimal
 import functools
@@ -698,7 +699,7 @@ class Mapping(SchemaType):
                           mapping={'val': value}))
 
         elif self.unknown == 'preserve':
-            result.update(value)
+            result.update(copy.deepcopy(value))
 
         if error is not None:
             raise error

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2856,6 +2856,21 @@ class TestSchemaNode(unittest.TestCase):
         schema.children = list(reversed(schema.children))
         compare_children(schema, schema.clone())
 
+    def test_clone_mapping_references(self):
+        import colander
+        class Schema(colander.MappingSchema):
+            n1 = colander.SchemaNode(colander.Mapping(unknown='preserve'))
+        foo = {
+            "n1": {
+                "bar": {
+                    "baz": "qux",
+                },
+            },
+        }
+        bar = Schema().serialize(foo)
+        bar["n1"]["bar"]["baz"] = "foobar"
+        self.assertEqual(foo["n1"]["bar"]["baz"], "qux")
+
     def test_bind(self):
         from colander import deferred
         inner_typ = DummyType()


### PR DESCRIPTION
This avoids keeping a reference, which leads to odd behaviors. Calling
serialize() on an object, one would expect the dictionary to not have
any reference to the original object.