### PR TITLE
Object serialization

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -2323,7 +2323,7 @@ class SequenceSchema(SchemaNode):
         cloned.__dict__.update(attributes)
         return cloned
 
-class ObjectSchema(colander.SchemaNode):
+class ObjectSchema(SchemaNode):
     """ A schema describing a python object.
     """
     schema_type = Object

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -764,7 +764,9 @@ class Mapping(SchemaType):
 
 
 class Object(colander.Mapping):
-    """ A type which represents a generic python object.
+    """ A type which represents a generic python object,
+    i.e. specifically one that inherits, either directly or indirectly,
+    from `__builtin__.object`.
 
     This type will serialize and deserialize instances by treating
     them as dictionaries, allowing the use of the parent `Mapping` type

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -2323,6 +2323,21 @@ class SequenceSchema(SchemaNode):
         cloned.__dict__.update(attributes)
         return cloned
 
+class ObjectSchema(colander.SchemaNode):
+    schema_type = ObjectType
+    instance = None
+
+    def serialize(self, appstruct):
+        if not self.instance:
+            self.instance = appstruct
+        return super(ObjectSchema, self).serialize(appstruct)
+
+    def deserialize(self, cstruct):
+        appstruct = super(ObjectSchema, self).deserialize(cstruct)
+        if not self.instance:
+            self.instance = appstruct
+        return appstruct
+
 class deferred(object):
     """ A decorator which can be used to define deferred schema values
     (missing values, widgets, validators, etc.)"""

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -763,7 +763,7 @@ class Mapping(SchemaType):
         return appstruct[path]
 
 
-class Object(colander.Mapping):
+class Object(Mapping):
     """ A type which represents a generic python object,
     i.e. specifically one that inherits, either directly or indirectly,
     from `__builtin__.object`.

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -763,7 +763,7 @@ class Mapping(SchemaType):
         return appstruct[path]
 
 
-class ObjectType(colander.Mapping):
+class Object(colander.Mapping):
     """ A type which represents a generic python object.
 
     This type will serialize and deserialize instances by treating
@@ -775,10 +775,10 @@ class ObjectType(colander.Mapping):
 
     def serialize(self, node, appstruct):
         appstruct = appstruct.__dict__
-        return super(ObjectType, self).serialize(node, appstruct)
+        return super(Object, self).serialize(node, appstruct)
 
     def deserialize(self, node, cstruct):
-        data = super(ObjectType, self).deserialize(node, cstruct)
+        data = super(Object, self).deserialize(node, cstruct)
         appstruct = node.instance.__class__()
         appstruct.__dict__.update(data)
         return appstruct
@@ -2324,7 +2324,7 @@ class SequenceSchema(SchemaNode):
         return cloned
 
 class ObjectSchema(colander.SchemaNode):
-    schema_type = ObjectType
+    schema_type = Object
     instance = None
 
     def serialize(self, appstruct):

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -784,23 +784,6 @@ class ObjectType(colander.Mapping):
         return appstruct
 
 
-class PickleType(colander.SchemaType):
-    """ A type representing a generic python object.
-
-    This uses the pickle standard library to serialize/deserialize
-    an arbitrary python object using a binary (rather than text) format.
-    If a text format is desired consider using ``ObjectType`` instead.
-    """
-
-    def serialize(self, node, appstruct):
-        cstruct = pickle.dumps(appstruct)
-        return cstruct
-
-    def deserialize(self, node, cstruct):
-        appstruct = pickle.loads(cstruct)
-        return appstruct
-
-
 class Positional(object):
     """
     Marker abstract base class meaning 'this type has children which

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -784,6 +784,23 @@ class ObjectType(colander.Mapping):
         return appstruct
 
 
+class PickleType(colander.SchemaType):
+    """ A type representing a generic python object.
+
+    This uses the pickle standard library to serialize/deserialize
+    an arbitrary python object using a binary (rather than text) format.
+    If a text format is desired consider using ``ObjectType`` instead.
+    """
+
+    def serialize(self, node, appstruct):
+        cstruct = pickle.dumps(appstruct)
+        return cstruct
+
+    def deserialize(self, node, cstruct):
+        appstruct = pickle.loads(cstruct)
+        return appstruct
+
+
 class Positional(object):
     """
     Marker abstract base class meaning 'this type has children which

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -763,6 +763,27 @@ class Mapping(SchemaType):
         return appstruct[path]
 
 
+class ObjectType(colander.Mapping):
+    """ A type which represents a generic python object.
+
+    This type will serialize and deserialize instances by treating
+    them as dictionaries, allowing the use of the parent `Mapping` type
+    for this purpose. Note that inherited class attributes will not be
+    handled unless they are explicitly set on the instance (e.g.
+    via self.).
+    """
+
+    def serialize(self, node, appstruct):
+        appstruct = appstruct.__dict__
+        return super(ObjectType, self).serialize(node, appstruct)
+
+    def deserialize(self, node, cstruct):
+        data = super(ObjectType, self).deserialize(node, cstruct)
+        appstruct = node.instance.__class__()
+        appstruct.__dict__.update(data)
+        return appstruct
+
+
 class Positional(object):
     """
     Marker abstract base class meaning 'this type has children which

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -776,10 +776,14 @@ class Object(Mapping):
     """
 
     def serialize(self, node, appstruct):
+        if appstruct is null:
+            return null
         appstruct = appstruct.__dict__
         return super(Object, self).serialize(node, appstruct)
 
     def deserialize(self, node, cstruct):
+        if cstruct is null:
+            return null
         data = super(Object, self).deserialize(node, cstruct)
         appstruct = node.instance.__class__()
         appstruct.__dict__.update(data)

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -2324,6 +2324,8 @@ class SequenceSchema(SchemaNode):
         return cloned
 
 class ObjectSchema(colander.SchemaNode):
+    """ A schema describing a python object.
+    """
     schema_type = Object
     instance = None
 


### PR DESCRIPTION
Hello! This PR is WIP, I wanted some feedback on whether it would be useful before proceeding / fleshing it out.

I wrote up a simple object serializer for colander in order to implement [this benchmark](https://github.com/voidfiles/python-serialization-benchmark/pull/8). The object serializer is a thin wrapper around colander's usual `Mapping` type, taking advantage of the fact that python objects have a convenient dict representation in `__dict__`.

Some implementation considerations:
- passing in the class to be serialized at `__init__` time seems desirable, but it would require that the class be available at schema definition time (e.g. if an object is nested inside another schema), which may be an inconvenient assumption to make. So, I opted against expecting the class/instance to be provided to the schema constructor
- instead, since we know the instance will be available at serialization time and fed correctly into colander based on the structure of the data, we derive the class from the instance at serialization time. Thoughts on this?
- this also sets the `instance` attribute on the `ObjectSchema` at that time, so that deserialization is able to create an instance of the appropriate class at deserialization time
- although... now that I think about it, this wouldn't really work since at deserialization time it's unlikely we would have performed a prior serialization using the same `ObjectSchema` instance, meaning we would not have the class available and would not know which class to create an instance of... maybe passing in the class to the constructor is necessary after all? Or perhaps the class should be included somehow in the serialization, i.e. in the `cstruct`?

Anyway, just putting this up in case y'all have any thoughts on the implementation or even the necessity/usefulness, and I can flesh it out / add tests, docs and whatnot as needed. Thanks!
