### PR TITLE
Serialize/deserialize dates and datetimes with custom formats.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -138,3 +138,4 @@ Contributors
 - Sergiu Bivol, 2016/04/23
 - Denis Nasyrov, 2016/08/23
 - Gabriela Surita, 2017/01/31
+- Manuel Vázquez, 2018/11/22

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2096,7 +2096,7 @@ class TestGlobalObject(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.serialize(node, colander.tests)
         self.assertEqual(result, 'colander.tests')
-        
+
         from colander import tests
         typ = self._makeOne()
         node = DummySchemaNode(None)
@@ -2127,7 +2127,7 @@ class TestGlobalObject(unittest.TestCase):
         node = DummySchemaNode(None)
         for name in names:
             result = typ.deserialize(node, name)
-            self.assertEqual(result, self.__class__)         
+            self.assertEqual(result, self.__class__)
 
     def test_deserialize_class_fail(self):
         import colander
@@ -2139,7 +2139,7 @@ class TestGlobalObject(unittest.TestCase):
            e = invalid_exc(typ.deserialize, node, name)
            self.assertEqual(e.msg.interpolate(),
                             'The dotted name "{0}" cannot be imported'.format(name))
-           
+
     def test_serialize_fail(self):
         typ = self._makeOne()
         node = DummySchemaNode(None)
@@ -2261,18 +2261,6 @@ class TestDateTime(unittest.TestCase):
         expected = dt.isoformat()
         self.assertEqual(result, expected)
 
-    def test_serialize_with_tzware_datetime_custom_format(self):
-        from iso8601 import iso8601
-        fmt = '%Y%m%d.%H%M%S%z'
-        typ = self._makeOne(format=fmt)
-        dt = self._dt()
-        tzinfo = iso8601.FixedOffset(1, 0, 'myname')
-        dt = dt.replace(tzinfo=tzinfo)
-        node = DummySchemaNode(None)
-        result = typ.serialize(node, dt)
-        expected = dt.strftime(fmt)
-        self.assertEqual(result, expected)
-
     def test_deserialize_date(self):
         import datetime
         from iso8601 import iso8601
@@ -2337,7 +2325,7 @@ class TestDateTime(unittest.TestCase):
 
     def test_deserialize_datetime_with_custom_format(self):
         from iso8601 import iso8601
-        fmt = '%Y%m%d.%z.%H%M%S'
+        fmt = '%Y%m%d.%H%M%S'
         typ = self._makeOne(format=fmt)
         dt = self._dt()
         tzinfo = iso8601.FixedOffset(1, 0, 'myname')

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2207,17 +2207,6 @@ class TestDateTime(unittest.TestCase):
         expected = expected.replace(tzinfo=typ.default_tzinfo).isoformat()
         self.assertEqual(result, expected)
 
-    def test_serialize_date_with_custom_format(self):
-        import datetime
-        fmt = '%m,%Y,%d'
-        typ = self._makeOne(format=fmt)
-        date = self._today()
-        node = DummySchemaNode(None)
-        result = typ.serialize(node, date)
-        expected = datetime.datetime.combine(date, datetime.time())
-        expected = expected.replace(tzinfo=typ.default_tzinfo).strftime(fmt)
-        self.assertEqual(result, expected)
-
     def test_serialize_with_naive_datetime(self):
         typ = self._makeOne()
         node = DummySchemaNode(None)
@@ -2267,19 +2256,6 @@ class TestDateTime(unittest.TestCase):
         date = self._today()
         typ = self._makeOne()
         formatted = date.isoformat()
-        node = DummySchemaNode(None)
-        result = typ.deserialize(node, formatted)
-        expected = datetime.datetime.combine(result, datetime.time())
-        expected = expected.replace(tzinfo=iso8601.UTC)
-        self.assertEqual(result.isoformat(), expected.isoformat())
-
-    def test_deserialize_date_with_custom_format(self):
-        import datetime
-        from iso8601 import iso8601
-        date = self._today()
-        fmt = '%d/%m/%Y'
-        typ = self._makeOne(format=fmt)
-        formatted = date.strftime(fmt)
         node = DummySchemaNode(None)
         result = typ.deserialize(node, formatted)
         expected = datetime.datetime.combine(result, datetime.time())
@@ -2447,6 +2423,23 @@ class TestDate(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.deserialize(node, iso)
         self.assertEqual(result.isoformat(), dt.date().isoformat())
+
+    def test_serialize_date_with_custom_format(self):
+        fmt = '%m,%Y,%d'
+        typ = self._makeOne(format=fmt)
+        date = self._today()
+        node = DummySchemaNode(None)
+        result = typ.serialize(node, date)
+        self.assertEqual(result, date.strftime(fmt))
+
+    def test_deserialize_date_with_custom_format(self):
+        date = self._today()
+        fmt = '%d/%m/%Y'
+        typ = self._makeOne(format=fmt)
+        formatted = date.strftime(fmt)
+        node = DummySchemaNode(None)
+        result = typ.deserialize(node, formatted)
+        self.assertEqual(result, date)
 
 class TestTime(unittest.TestCase):
     def _makeOne(self, *arg, **kw):


### PR DESCRIPTION
Some external entities require you to serialize/deserialize dates and datetimes in custom formats.

For instance Systempay (the online payment platform of a French Bank) requires that [datetimes](https://paiement.systempay.fr/html/Doc/Payment_Form/en/Implementation_Guide_Interface_Payment_gateway_Systempay_v3.20.pdf) are given in 'YYYYDDHHMMSS'; without the '-' of the ISO. 