### PR TITLE
Handle microseconds in Time SchemaType

### DIFF
--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1829,7 +1829,7 @@ class Time(SchemaType):
                             mapping={'val':appstruct})
                           )
 
-        return appstruct.isoformat().split('.')[0]
+        return appstruct.isoformat()
 
     def deserialize(self, node, cstruct):
         if not cstruct:
@@ -1838,20 +1838,19 @@ class Time(SchemaType):
             result = iso8601.parse_date(cstruct)
             result = result.time()
         except (iso8601.ParseError, TypeError):
+            fmt = {
+                8:'%H:%M:%S',
+                5:'%H:%M'
+            }.get(len(cstruct), '%H:%M:%S.%f')
             try:
-                result = timeparse(cstruct, '%H:%M:%S')
-            except ValueError:
-                try:
-                    result = timeparse(cstruct, '%H:%M')
-                except Exception as e:
-                    raise Invalid(node,
-                                  _(self.err_template,
-                                    mapping={'val':cstruct, 'err':e})
-                                  )
+                result = datetime.datetime.strptime(cstruct, fmt).time()
+            except Exception as e:
+                raise Invalid(
+                    node, _(self.err_template,
+                            mapping={'val':cstruct, 'err':e})
+                )
         return result
 
-def timeparse(t, format):
-    return datetime.datetime(*time.strptime(t, format)[0:6]).time()
 
 class Enum(SchemaType):
     """A type representing a Python ``enum.Enum`` object.

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2402,7 +2402,7 @@ class TestTime(unittest.TestCase):
 
     def _dt(self):
         import datetime
-        return datetime.datetime(2010, 4, 26, 10, 48)
+        return datetime.datetime(2010, 4, 26, 10, 48, 0, 424242)
 
     def _now(self):
         import datetime
@@ -2435,7 +2435,7 @@ class TestTime(unittest.TestCase):
         time = self._now()
         node = DummySchemaNode(None)
         result = typ.serialize(node, time)
-        expected = time.isoformat().split('.')[0]
+        expected = time.isoformat()
         self.assertEqual(result, expected)
 
     def test_serialize_with_zero_time(self):
@@ -2444,7 +2444,7 @@ class TestTime(unittest.TestCase):
         time = datetime.time(0)
         node = DummySchemaNode(None)
         result = typ.serialize(node, time)
-        expected = time.isoformat().split('.')[0]
+        expected = time.isoformat()
         self.assertEqual(result, expected)
 
     def test_serialize_with_datetime(self):
@@ -2452,7 +2452,7 @@ class TestTime(unittest.TestCase):
         dt = self._dt()
         node = DummySchemaNode(None)
         result = typ.serialize(node, dt)
-        expected = dt.time().isoformat().split('.')[0]
+        expected = dt.time().isoformat()
         self.assertEqual(result, expected)
 
     def test_deserialize_invalid_ParseError(self):
@@ -2467,6 +2467,13 @@ class TestTime(unittest.TestCase):
         typ = self._makeOne()
         result = typ.deserialize(node, '11:00:11')
         self.assertEqual(result, datetime.time(11, 0, 11))
+
+    def test_deserialize_four_digit_string(self):
+        import datetime
+        node = DummySchemaNode(None)
+        typ = self._makeOne()
+        result = typ.deserialize(node, '11:00:11.424242')
+        self.assertEqual(result, datetime.time(11, 0, 11, 424242))
 
     def test_deserialize_two_digit_string(self):
         import datetime
@@ -2510,7 +2517,7 @@ class TestTime(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.deserialize(node, iso)
         self.assertEqual(result.isoformat(),
-                dt.time().isoformat().split('.')[0])
+                dt.time().isoformat())
 
 class TestEnum(unittest.TestCase):
     def _makeOne(self):


### PR DESCRIPTION
Actually, it is impossible to manage microseconds using Time SchemaType:
```
>>> from colander import Time
>>> from colander import SchemaNode
>>> from datetime import time
>>> node = SchemaNode(Time())
>>> node.deserialize('10:42:42.424242')
...
colander.Invalid: {'': 'Invalid time'}
>>> t = time(10,42,42,424242)
>>> node.serialize(t)
'10:42:42'
```
This PR handle full ISO format HH:MM[:SS[.mmmmmm]] for deserialization and HH:MM:SS[.mmmmmm] for serialization through time.isoformat.