### PR TITLE
Format Python code of colander to conform to the PEP 8 style guide.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+ignore =
+    # E731: do not assign a lambda expression, use a def
+    E731
+    # W503: line break before binary operator (flake8 is not PEP8 compliant)
+    W503
+    # W504: line break after binary operator (flake8 is not PEP8 compliant)
+    W504
+exclude =
+    colander/compat.py
+show-source = True

--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,4 @@ ignore =
 exclude =
     colander/compat.py
 show-source = True
+max-line-length = 79

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ env*/
 .*
 !/.gitignore
 !/.flake8
+!/.travis.yml

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,5 @@ coverage.xml
 distribute*.gz
 venv/
 env*/
-.*
-!/.gitignore
-!/.hgignore
-!/.flake8
-!/.travis.yml
+.idea
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ coverage.xml
 distribute*.gz
 venv/
 env*/
+.*
+!/.gitignore
+!/.flake8

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ venv/
 env*/
 .*
 !/.gitignore
+!/.hgignore
 !/.flake8
 !/.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,14 @@ matrix:
           env: TOXENV=pypy
         - python: pypy3
           env: TOXENV=pypy3
-        - python: 3.5
-          env: TOXENV=py2-cover,py3-cover,coverage
+        - python: 2.7
+          env: TOXENV=py27-cover
+        - python: 3.6
+          env: TOXENV=py36-cover,coverage
         - python: 3.5
           env: TOXENV=docs
+        - python: 3.6
+          env: TOXENV=lint
     allow_failures:
         - env: TOXENV=py38
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
           env: TOXENV=pypy
         - python: pypy3
           env: TOXENV=pypy3
-        - python: 2.7
-          env: TOXENV=py27-cover
         - python: 3.6
           env: TOXENV=py36-cover,coverage
         - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - python: pypy3
           env: TOXENV=pypy3
         - python: 3.6
-          env: TOXENV=py36-cover,coverage
+          env: TOXENV=py27-cover,py36-cover,coverage
         - python: 3.5
           env: TOXENV=docs
         - python: 3.6

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+- Format Python code of ``colander`` to conform to the PEP 8 style guide.
+  Add some linters (``flake8`` and ``setup.py check``) into ``tox.ini``.
+
 1.5.1 (2018-09-10)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ unreleased
 ==========
 
 - Format Python code of ``colander`` to conform to the PEP 8 style guide.
-  Add some linters (``flake8`` and ``setup.py check``) into ``tox.ini``.
+  Add some linters (``flake8``, ``black`` and other) into ``tox.ini``.
 
 1.5.1 (2018-09-10)
 ==================

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -138,3 +138,4 @@ Contributors
 - Sergiu Bivol, 2016/04/23
 - Denis Nasyrov, 2016/08/23
 - Gabriela Surita, 2017/01/31
+- Kirill Kuzminykh, 2019/01/27

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,15 @@
+graft colander
+graft docs
+prune docs/_build
+prune docs/.gitignore
+
+include README.rst CHANGES.rst
+include CONTRIBUTORS.txt LICENSE.txt COPYRIGHT.txt
+
+include .flake8 setup.cfg pyproject.toml
+include tox.ini .travis.yml rtd.txt
+include contributing.md RELEASING.txt TODO.txt
+graft .github
+
+global-exclude __pycache__ *.py[cod]
+global-exclude .DS_Store

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -2546,7 +2546,8 @@ class deferred(object):
     def __init__(self, wrapped):
         try:
             functools.update_wrapper(self, wrapped)
-        except AttributeError:  # non-function
+        except AttributeError:  # pragma: no cover
+            # non-function (raises in Python 2)
             self.__doc__ = getattr(wrapped, '__doc__', None)
         self.wrapped = wrapped
 

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -1842,7 +1842,7 @@ class DateTime(SchemaType):
             else:
                 result = iso8601.parse_date(
                     cstruct, default_timezone=self.default_tzinfo
-            )
+                )
         except (ValueError, iso8601.ParseError) as e:
             raise Invalid(
                 node, _(self.err_template, mapping={'val': cstruct, 'err': e})

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -2546,7 +2546,7 @@ class deferred(object):
     def __init__(self, wrapped):
         try:
             functools.update_wrapper(self, wrapped)
-        except AttributeError:  # pragma: no cover
+        except AttributeError:
             # non-function (raises in Python 2)
             self.__doc__ = getattr(wrapped, '__doc__', None)
         self.wrapped = wrapped

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -13,13 +13,7 @@ import types
 
 from iso8601 import iso8601
 
-from .compat import (
-    text_,
-    text_type,
-    string_types,
-    xrange,
-    is_nonstr_iter,
-)
+from .compat import text_, text_type, string_types, xrange, is_nonstr_iter
 
 
 _ = translationstring.TranslationStringFactory('colander')
@@ -108,6 +102,7 @@ class Invalid(Exception):
     The constructor additionally may receive an optional ``value``
     keyword, indicating the value related to the error.
     """
+
     pos = None
     positional = False
 
@@ -323,7 +318,7 @@ class Function(object):
             warnings.warn(
                 'The "message" argument has been deprecated, use "msg" '
                 'instead.',
-                DeprecationWarning
+                DeprecationWarning,
             )
             msg = message
         self.msg = msg
@@ -332,12 +327,18 @@ class Function(object):
         result = self.function(value)
         if not result:
             raise Invalid(
-                node, translationstring.TranslationString(
-                    self.msg, mapping={'val': value}))
+                node,
+                translationstring.TranslationString(
+                    self.msg, mapping={'val': value}
+                ),
+            )
         if isinstance(result, string_types):
             raise Invalid(
-                node, translationstring.TranslationString(
-                    result, mapping={'val': value}))
+                node,
+                translationstring.TranslationString(
+                    result, mapping={'val': value}
+                ),
+            )
 
 
 class Regex(object):
@@ -430,6 +431,7 @@ class Range(object):
     provided, it defaults to ``'${val} is greater than maximum value
     ${max}'``.
     """
+
     _MIN_ERR = _('${val} is less than minimum value ${min}')
     _MAX_ERR = _('${val} is greater than maximum value ${max}')
 
@@ -443,13 +445,15 @@ class Range(object):
         if self.min is not None:
             if value < self.min:
                 min_err = _(
-                    self.min_err, mapping={'val': value, 'min': self.min})
+                    self.min_err, mapping={'val': value, 'min': self.min}
+                )
                 raise Invalid(node, min_err)
 
         if self.max is not None:
             if value > self.max:
                 max_err = _(
-                    self.max_err, mapping={'val': value, 'max': self.max})
+                    self.max_err, mapping={'val': value, 'max': self.max}
+                )
                 raise Invalid(node, max_err)
 
 
@@ -478,6 +482,7 @@ class Length(object):
         specified, it must be a string.  The string may contain the
         replacement target ``${max}``.
         """
+
     _MIN_ERR = _('Shorter than minimum length ${min}')
     _MAX_ERR = _('Longer than maximum length ${max}')
 
@@ -508,8 +513,10 @@ class OneOf(object):
     def __call__(self, node, value):
         if value not in self.choices:
             choices = ', '.join(['%s' % x for x in self.choices])
-            err = _('"${val}" is not one of ${choices}',
-                    mapping={'val': value, 'choices': choices})
+            err = _(
+                '"${val}" is not one of ${choices}',
+                mapping={'val': value, 'choices': choices},
+            )
             raise Invalid(node, err)
 
 
@@ -523,6 +530,7 @@ class NoneOf(object):
     ``${choices}`` and ``${val}``, representing the set of forbidden values
     and the provided value respectively.
     """
+
     _MSG_ERR = _('"${val}" must not be one of ${choices}')
 
     def __init__(self, choices, msg_err=_MSG_ERR):
@@ -545,9 +553,8 @@ class ContainsOnly(object):
     This validator is useful when attached to a schemanode with, e.g. a
     :class:`colander.Set` or another sequencetype.
     """
-    err_template = _(
-        'One or more of the choices you made was not acceptable'
-    )
+
+    err_template = _('One or more of the choices you made was not acceptable')
 
     def __init__(self, choices):
         self.choices = choices
@@ -556,7 +563,7 @@ class ContainsOnly(object):
         if not set(value).issubset(self.choices):
             err = _(
                 self.err_template,
-                mapping={'val': value, 'choices': self.choices}
+                mapping={'val': value, 'choices': self.choices},
             )
             raise Invalid(node, err)
 
@@ -568,14 +575,22 @@ def luhnok(node, value):
     try:
         checksum = _luhnok(value)
     except ValueError:
-        raise Invalid(node,
-                      _('"${val}" is not a valid credit card number',
-                        mapping={'val': value}))
+        raise Invalid(
+            node,
+            _(
+                '"${val}" is not a valid credit card number',
+                mapping={'val': value},
+            ),
+        )
 
     if (checksum % 10) != 0:
-        raise Invalid(node,
-                      _('"${val}" is not a valid credit card number',
-                        mapping={'val': value}))
+        raise Invalid(
+            node,
+            _(
+                '"${val}" is not a valid credit card number',
+                mapping={'val': value},
+            ),
+        )
 
 
 def _luhnok(value):
@@ -691,7 +706,8 @@ class Mapping(SchemaType):
         if value not in ('ignore', 'raise', 'preserve'):
             raise ValueError(
                 'unknown attribute must be one of "ignore", "raise", '
-                'or "preserve"')
+                'or "preserve"'
+            )
         self._unknown = value
 
     def _get_unknown(self):
@@ -708,8 +724,10 @@ class Mapping(SchemaType):
         except Exception as e:
             raise Invalid(
                 node,
-                _('"${val}" is not a mapping type: ${err}',
-                  mapping={'val': value, 'err': e})
+                _(
+                    '"${val}" is not a mapping type: ${err}',
+                    mapping={'val': value, 'err': e},
+                ),
             )
 
     def cstruct_children(self, node, cstruct):
@@ -751,9 +769,13 @@ class Mapping(SchemaType):
         if self.unknown == 'raise':
             if value:
                 raise UnsupportedFields(
-                    node, value,
-                    msg=_('Unrecognized keys in mapping: "${val}"',
-                          mapping={'val': value}))
+                    node,
+                    value,
+                    msg=_(
+                        'Unrecognized keys in mapping: "${val}"',
+                        mapping={'val': value},
+                    ),
+                )
 
         elif self.unknown == 'preserve':
             result.update(copy.deepcopy(value))
@@ -794,8 +816,9 @@ class Mapping(SchemaType):
         for subnode in node.children:
             name = subnode.name
             substruct = appstruct.get(name, null)
-            result.update(subnode.typ.flatten(subnode, substruct,
-                                              prefix=selfprefix))
+            result.update(
+                subnode.typ.flatten(subnode, substruct, prefix=selfprefix)
+            )
         return result
 
     def unflatten(self, node, paths, fstruct):
@@ -807,7 +830,8 @@ class Mapping(SchemaType):
             next_node = node[next_name]
             next_appstruct = appstruct[next_name]
             appstruct[next_name] = next_node.typ.set_value(
-                next_node, next_appstruct, rest, value)
+                next_node, next_appstruct, rest, value
+            )
         else:
             appstruct[path] = value
         return appstruct
@@ -848,8 +872,7 @@ class Tuple(Positional, SchemaType):
     def _validate(self, node, value):
         if not hasattr(value, '__iter__'):
             raise Invalid(
-                node,
-                _('"${val}" is not iterable', mapping={'val': value})
+                node, _('"${val}" is not iterable', mapping={'val': value})
             )
 
         valuelen, nodelen = len(value), len(node.children)
@@ -857,9 +880,11 @@ class Tuple(Positional, SchemaType):
         if valuelen != nodelen:
             raise Invalid(
                 node,
-                _('"${val}" has an incorrect number of elements '
-                  '(expected ${exp}, was ${was})',
-                  mapping={'val': value, 'exp': nodelen, 'was': valuelen})
+                _(
+                    '"${val}" has an incorrect number of elements '
+                    '(expected ${exp}, was ${was})',
+                    mapping={'val': value, 'exp': nodelen, 'was': valuelen},
+                ),
             )
 
         return list(value)
@@ -926,8 +951,9 @@ class Tuple(Positional, SchemaType):
 
         for num, subnode in enumerate(node.children):
             substruct = appstruct[num]
-            result.update(subnode.typ.flatten(subnode, substruct,
-                                              prefix=selfprefix))
+            result.update(
+                subnode.typ.flatten(subnode, substruct, prefix=selfprefix)
+            )
         return result
 
     def unflatten(self, node, paths, fstruct):
@@ -951,7 +977,8 @@ class Tuple(Positional, SchemaType):
         if rest is not None:
             next_appstruct = appstruct[index]
             appstruct[index] = next_node.typ.set_value(
-                next_node, next_appstruct, rest, value)
+                next_node, next_appstruct, rest, value
+            )
         else:
             appstruct[index] = value
         return tuple(appstruct)
@@ -996,7 +1023,7 @@ class Set(SchemaType):
         if not is_nonstr_iter(cstruct):
             raise Invalid(
                 node,
-                _('${cstruct} is not iterable', mapping={'cstruct': cstruct})
+                _('${cstruct} is not iterable', mapping={'cstruct': cstruct}),
             )
 
         return set(cstruct)
@@ -1027,7 +1054,7 @@ class List(SchemaType):
         if not is_nonstr_iter(cstruct):
             raise Invalid(
                 node,
-                _('${cstruct} is not iterable', mapping={'cstruct': cstruct})
+                _('${cstruct} is not iterable', mapping={'cstruct': cstruct}),
             )
 
         return list(cstruct)
@@ -1075,16 +1102,18 @@ class Sequence(Positional, SchemaType):
         self.accept_scalar = accept_scalar
 
     def _validate(self, node, value, accept_scalar):
-        if (hasattr(value, '__iter__') and
-                not hasattr(value, 'get') and
-                not isinstance(value, string_types)):
+        if (
+            hasattr(value, '__iter__')
+            and not hasattr(value, 'get')
+            and not isinstance(value, string_types)
+        ):
             return list(value)
         if accept_scalar:
             return [value]
         else:
-            raise Invalid(node, _('"${val}" is not iterable',
-                                  mapping={'val': value})
-                          )
+            raise Invalid(
+                node, _('"${val}" is not iterable', mapping={'val': value})
+            )
 
     def cstruct_children(self, node, cstruct):
         if cstruct is null:
@@ -1188,8 +1217,11 @@ class Sequence(Positional, SchemaType):
         for num, subval in enumerate(appstruct):
             subname = '%s%s' % (selfprefix, num)
             subprefix = subname + '.'
-            result.update(childnode.typ.flatten(
-                childnode, subval, prefix=subprefix, listitem=True))
+            result.update(
+                childnode.typ.flatten(
+                    childnode, subval, prefix=subprefix, listitem=True
+                )
+            )
 
         return result
 
@@ -1206,8 +1238,9 @@ class Sequence(Positional, SchemaType):
                 return '%s.%s' % (child_name, suffix)
             return child_name
 
-        mapstruct = _unflatten_mapping(node, paths, fstruct,
-                                       get_child, rewrite_subpath)
+        mapstruct = _unflatten_mapping(
+            node, paths, fstruct, get_child, rewrite_subpath
+        )
         return [mapstruct[str(index)] for index in xrange(len(mapstruct))]
 
     def set_value(self, node, appstruct, path, value):
@@ -1217,7 +1250,8 @@ class Sequence(Positional, SchemaType):
             next_node = node.children[0]
             next_appstruct = appstruct[index]
             appstruct[index] = next_node.typ.set_value(
-                next_node, next_appstruct, rest, value)
+                next_node, next_appstruct, rest, value
+            )
         else:
             index = int(path)
             appstruct[index] = value
@@ -1321,10 +1355,13 @@ class String(SchemaType):
                     result = result.encode(self.encoding)
             return result
         except Exception as e:
-            raise Invalid(node,
-                          _('${val} cannot be serialized: ${err}',
-                            mapping={'val': appstruct, 'err': e})
-                          )
+            raise Invalid(
+                node,
+                _(
+                    '${val} cannot be serialized: ${err}',
+                    mapping={'val': appstruct, 'err': e},
+                ),
+            )
 
     def deserialize(self, node, cstruct):
         if cstruct == '' and self.allow_empty:
@@ -1343,9 +1380,13 @@ class String(SchemaType):
             else:
                 raise Invalid(node)
         except Exception as e:
-            raise Invalid(node,
-                          _('${val} is not a string: ${err}',
-                            mapping={'val': cstruct, 'err': e}))
+            raise Invalid(
+                node,
+                _(
+                    '${val} is not a string: ${err}',
+                    mapping={'val': cstruct, 'err': e},
+                ),
+            )
 
         return result
 
@@ -1365,10 +1406,9 @@ class Number(SchemaType):
         try:
             return str(self.num(appstruct))
         except Exception:
-            raise Invalid(node,
-                          _('"${val}" is not a number',
-                            mapping={'val': appstruct}),
-                          )
+            raise Invalid(
+                node, _('"${val}" is not a number', mapping={'val': appstruct})
+            )
 
     def deserialize(self, node, cstruct):
         if cstruct != 0 and not cstruct:
@@ -1377,10 +1417,9 @@ class Number(SchemaType):
         try:
             return self.num(cstruct)
         except Exception:
-            raise Invalid(node,
-                          _('"${val}" is not a number',
-                            mapping={'val': cstruct})
-                          )
+            raise Invalid(
+                node, _('"${val}" is not a number', mapping={'val': cstruct})
+            )
 
 
 class Integer(Number):
@@ -1393,6 +1432,7 @@ class Integer(Number):
     The subnodes of the :class:`colander.SchemaNode` that wraps
     this type are ignored.
     """
+
     num = int
 
 
@@ -1409,6 +1449,7 @@ class Float(Number):
     The subnodes of the :class:`colander.SchemaNode` that wraps
     this type are ignored.
     """
+
     num = float
 
 
@@ -1510,8 +1551,13 @@ class Boolean(SchemaType):
     this type are ignored.
     """
 
-    def __init__(self, false_choices=('false', '0'), true_choices=(),
-                 false_val='false', true_val='true'):
+    def __init__(
+        self,
+        false_choices=('false', '0'),
+        true_choices=(),
+        false_val='false',
+        true_val='true',
+    ):
 
         self.false_choices = false_choices
         self.true_choices = true_choices
@@ -1534,9 +1580,9 @@ class Boolean(SchemaType):
         try:
             result = str(cstruct)
         except Exception:
-            raise Invalid(node,
-                          _('${val} is not a string', mapping={'val': cstruct})
-                          )
+            raise Invalid(
+                node, _('${val} is not a string', mapping={'val': cstruct})
+            )
         result = result.lower()
 
         if result in self.false_choices:
@@ -1545,13 +1591,18 @@ class Boolean(SchemaType):
             if result in self.true_choices:
                 return True
             else:
-                raise Invalid(node,
-                              _('"${val}" is neither in (${false_choices}) '
-                                'nor in (${true_choices})',
-                                mapping={'val': cstruct,
-                                         'false_choices': self.false_reprs,
-                                         'true_choices': self.true_reprs})
-                              )
+                raise Invalid(
+                    node,
+                    _(
+                        '"${val}" is neither in (${false_choices}) '
+                        'nor in (${true_choices})',
+                        mapping={
+                            'val': cstruct,
+                            'false_choices': self.false_reprs,
+                            'true_choices': self.true_reprs,
+                        },
+                    ),
+                )
 
         return True
 
@@ -1605,19 +1656,21 @@ class GlobalObject(SchemaType):
     def _pkg_resources_style(self, node, value):
         """ package.module:attr style """
         import pkg_resources
+
         if value.startswith('.') or value.startswith(':'):
             if not self.package:
                 raise Invalid(
                     node,
-                    _('relative name "${val}" irresolveable without package',
-                      mapping={'val': value})
+                    _(
+                        'relative name "${val}" irresolveable without package',
+                        mapping={'val': value},
+                    ),
                 )
             if value in ['.', ':']:
                 value = self.package.__name__
             else:
                 value = self.package.__name__ + value
-        return pkg_resources.EntryPoint.parse(
-            'x=%s' % value).load(False)
+        return pkg_resources.EntryPoint.parse('x=%s' % value).load(False)
 
     def _zope_dottedname_style(self, node, value):
         """ package.module.attr style """
@@ -1626,8 +1679,10 @@ class GlobalObject(SchemaType):
             if self.package is None:
                 raise Invalid(
                     node,
-                    _('relative name "${val}" irresolveable without package',
-                      mapping={'val': value})
+                    _(
+                        'relative name "${val}" irresolveable without package',
+                        mapping={'val': value},
+                    ),
                 )
             name = module.split('.')
         else:
@@ -1636,8 +1691,11 @@ class GlobalObject(SchemaType):
                 if module is None:
                     raise Invalid(
                         node,
-                        _('relative name "${val}" irresolveable without '
-                          'package', mapping={'val': value})
+                        _(
+                            'relative name "${val}" irresolveable without '
+                            'package',
+                            mapping={'val': value},
+                        ),
                     )
                 module = module.split('.')
                 name.pop(0)
@@ -1669,28 +1727,31 @@ class GlobalObject(SchemaType):
                 return '{0.__module__}.{0.__name__}'.format(appstruct)
 
         except AttributeError:
-            raise Invalid(node,
-                          _('"${val}" has no __name__',
-                            mapping={'val': appstruct})
-                          )
+            raise Invalid(
+                node, _('"${val}" has no __name__', mapping={'val': appstruct})
+            )
 
     def deserialize(self, node, cstruct):
         if not cstruct:
             return null
 
         if not isinstance(cstruct, string_types):
-            raise Invalid(node,
-                          _('"${val}" is not a string',
-                            mapping={'val': cstruct}))
+            raise Invalid(
+                node, _('"${val}" is not a string', mapping={'val': cstruct})
+            )
         try:
             if ':' in cstruct:
                 return self._pkg_resources_style(node, cstruct)
             else:
                 return self._zope_dottedname_style(node, cstruct)
         except ImportError:
-            raise Invalid(node,
-                          _('The dotted name "${name}" cannot be imported',
-                            mapping={'name': cstruct}))
+            raise Invalid(
+                node,
+                _(
+                    'The dotted name "${name}" cannot be imported',
+                    mapping={'name': cstruct},
+                ),
+            )
 
 
 class DateTime(SchemaType):
@@ -1738,6 +1799,7 @@ class DateTime(SchemaType):
     The subnodes of the :class:`colander.SchemaNode` that wraps
     this type are ignored.
     """
+
     err_template = _('Invalid date')
 
     def __init__(self, default_tzinfo=iso8601.UTC):
@@ -1752,10 +1814,13 @@ class DateTime(SchemaType):
             appstruct = datetime.datetime.combine(appstruct, datetime.time())
 
         if not isinstance(appstruct, datetime.datetime):
-            raise Invalid(node,
-                          _('"${val}" is not a datetime object',
-                            mapping={'val': appstruct})
-                          )
+            raise Invalid(
+                node,
+                _(
+                    '"${val}" is not a datetime object',
+                    mapping={'val': appstruct},
+                ),
+            )
 
         if appstruct.tzinfo is None:
             appstruct = appstruct.replace(tzinfo=self.default_tzinfo)
@@ -1767,10 +1832,12 @@ class DateTime(SchemaType):
 
         try:
             result = iso8601.parse_date(
-                cstruct, default_timezone=self.default_tzinfo)
+                cstruct, default_timezone=self.default_tzinfo
+            )
         except iso8601.ParseError as e:
-            raise Invalid(node, _(self.err_template,
-                                  mapping={'val': cstruct, 'err': e}))
+            raise Invalid(
+                node, _(self.err_template, mapping={'val': cstruct, 'err': e})
+            )
         return result
 
 
@@ -1824,10 +1891,10 @@ class Date(SchemaType):
             appstruct = appstruct.date()
 
         if not isinstance(appstruct, datetime.date):
-            raise Invalid(node,
-                          _('"${val}" is not a date object',
-                            mapping={'val': appstruct})
-                          )
+            raise Invalid(
+                node,
+                _('"${val}" is not a date object', mapping={'val': appstruct}),
+            )
 
         return appstruct.isoformat()
 
@@ -1838,10 +1905,9 @@ class Date(SchemaType):
             result = iso8601.parse_date(cstruct)
             result = result.date()
         except iso8601.ParseError as e:
-            raise Invalid(node,
-                          _(self.err_template,
-                            mapping={'val': cstruct, 'err': e})
-                          )
+            raise Invalid(
+                node, _(self.err_template, mapping={'val': cstruct, 'err': e})
+            )
         return result
 
 
@@ -1896,10 +1962,10 @@ class Time(SchemaType):
         if not isinstance(appstruct, datetime.time):
             if not appstruct:
                 return null
-            raise Invalid(node,
-                          _('"${val}" is not a time object',
-                            mapping={'val': appstruct})
-                          )
+            raise Invalid(
+                node,
+                _('"${val}" is not a time object', mapping={'val': appstruct}),
+            )
 
         return appstruct.isoformat().split('.')[0]
 
@@ -1916,10 +1982,13 @@ class Time(SchemaType):
                 try:
                     result = timeparse(cstruct, '%H:%M')
                 except Exception as e:
-                    raise Invalid(node,
-                                  _(self.err_template,
-                                    mapping={'val': cstruct, 'err': e})
-                                  )
+                    raise Invalid(
+                        node,
+                        _(
+                            self.err_template,
+                            mapping={'val': cstruct, 'err': e},
+                        ),
+                    )
         return result
 
 
@@ -1957,8 +2026,7 @@ class Enum(SchemaType):
                 v = getattr(e, self.attr)
                 if v in self.values:
                     raise ValueError(
-                        '%r is not unique in %r',
-                        v, self.enum_cls
+                        '%r is not unique in %r', v, self.enum_cls
                     )
                 self.values[v] = e
 
@@ -1967,9 +2035,13 @@ class Enum(SchemaType):
             return null
 
         if not isinstance(appstruct, self.enum_cls):
-            raise Invalid(node, _('"${val}" is not a valid "${cls}"',
-                                  mapping={'val': appstruct,
-                                           'cls': self.enum_cls.__name__}))
+            raise Invalid(
+                node,
+                _(
+                    '"${val}" is not a valid "${cls}"',
+                    mapping={'val': appstruct, 'cls': self.enum_cls.__name__},
+                ),
+            )
 
         return self.typ.serialize(node, getattr(appstruct, self.attr))
 
@@ -1979,9 +2051,13 @@ class Enum(SchemaType):
             return null
 
         if result not in self.values:
-            raise Invalid(node, _('"${val}" is not a valid "${cls}"',
-                                  mapping={'val': cstruct,
-                                           'cls': self.enum_cls.__name__}))
+            raise Invalid(
+                node,
+                _(
+                    '"${val}" is not a valid "${cls}"',
+                    mapping={'val': cstruct, 'cls': self.enum_cls.__name__},
+                ),
+            )
         return self.values[result]
 
 
@@ -2234,9 +2310,13 @@ class _SchemaNode(object):
         if appstruct is null:
             appstruct = self.missing
             if appstruct is required:
-                raise Invalid(self, _(self.missing_msg,
-                                      mapping={'title': self.title,
-                                               'name': self.name}))
+                raise Invalid(
+                    self,
+                    _(
+                        self.missing_msg,
+                        mapping={'title': self.title, 'name': self.name},
+                    ),
+                )
 
             if isinstance(appstruct, deferred):
                 # unbound schema with deferreds
@@ -2328,7 +2408,7 @@ class _SchemaNode(object):
                 'exception.  Returning [] for compatibility although it '
                 'may not be the right value.' % self.typ.__class__,
                 DeprecationWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             return []
         return cstruct_children(self, cstruct)
@@ -2418,9 +2498,7 @@ class _SchemaMeta(type):
 
 # metaclass spelling compatibility across Python 2 and Python 3
 SchemaNode = _SchemaMeta(
-    'SchemaNode',
-    (_SchemaNode,),
-    {'__doc__': _SchemaNode.__doc__}
+    'SchemaNode', (_SchemaNode,), {'__doc__': _SchemaNode.__doc__}
 )
 
 
@@ -2441,8 +2519,9 @@ class SequenceSchema(SchemaNode):
     def __init__(self, *args, **kw):
         SchemaNode.__init__(self, *args, **kw)
         if len(self.children) != 1:
-            raise Invalid(self,
-                          'Sequence schemas must have exactly one child node')
+            raise Invalid(
+                self, 'Sequence schemas must have exactly one child node'
+            )
 
     def clone(self):
         """ Clone the schema node and return the clone.  All subnodes
@@ -2475,13 +2554,16 @@ class deferred(object):
         return self.wrapped(node, kw)
 
 
-def _unflatten_mapping(node, paths, fstruct,
-                       get_child=None, rewrite_subpath=None):
+def _unflatten_mapping(
+    node, paths, fstruct, get_child=None, rewrite_subpath=None
+):
     if get_child is None:
         get_child = node.__getitem__
     if rewrite_subpath is None:
+
         def rewrite_subpath(subpath):
             return subpath
+
     node_name = node.name
     if node_name:
         prefix = node_name + '.'
@@ -2500,7 +2582,7 @@ def _unflatten_mapping(node, paths, fstruct,
         assert path.startswith(prefix), "Bad node: %s" % path
         subpath = path[prefix_len:]
         if '.' in subpath:
-            name = subpath[:subpath.index('.')]
+            name = subpath[: subpath.index('.')]
         else:
             name = subpath
         if curname is None:
@@ -2508,7 +2590,8 @@ def _unflatten_mapping(node, paths, fstruct,
         elif name != curname:
             subnode = get_child(curname)
             appstruct[curname] = subnode.typ.unflatten(
-                subnode, subpaths, subfstruct)
+                subnode, subpaths, subfstruct
+            )
             subfstruct = {}
             subpaths = []
             curname = name
@@ -2518,7 +2601,8 @@ def _unflatten_mapping(node, paths, fstruct,
     if curname is not None:
         subnode = get_child(curname)
         appstruct[curname] = subnode.typ.unflatten(
-            subnode, subpaths, subfstruct)
+            subnode, subpaths, subfstruct
+        )
     return appstruct
 
 

--- a/colander/compat.py
+++ b/colander/compat.py
@@ -4,7 +4,7 @@ import sys
 PY2 = sys.version_info[0] == 2
 PY3 = not PY2
 
-if PY2:
+if PY2:  # pragma: no cover
     string_types = (basestring,)
     text_type = unicode
 else:
@@ -20,7 +20,7 @@ def text_(s, encoding='latin-1', errors='strict'):
     return s  # pragma: no cover
 
 
-if PY2:
+if PY2:  # pragma: no cover
 
     def is_nonstr_iter(v):
         return hasattr(v, '__iter__')

--- a/colander/compat.py
+++ b/colander/compat.py
@@ -21,13 +21,18 @@ def text_(s, encoding='latin-1', errors='strict'):
 
 
 if PY2:
+
     def is_nonstr_iter(v):
         return hasattr(v, '__iter__')
+
+
 else:
+
     def is_nonstr_iter(v):
         if isinstance(v, str):
             return False
         return hasattr(v, '__iter__')
+
 
 try:
     xrange = xrange

--- a/colander/compat.py
+++ b/colander/compat.py
@@ -1,21 +1,24 @@
 import sys
 
+
 PY2 = sys.version_info[0] == 2
 PY3 = not PY2
 
 if PY2:
-    string_types = basestring,
+    string_types = (basestring,)
     text_type = unicode
 else:
-    string_types = str,
+    string_types = (str,)
     text_type = str
+
 
 def text_(s, encoding='latin-1', errors='strict'):
     """ If ``s`` is an instance of ``bytes``, return ``s.decode(encoding,
     errors)``, otherwise return ``s``"""
     if isinstance(s, bytes):
         return s.decode(encoding, errors)
-    return s # pragma: no cover
+    return s  # pragma: no cover
+
 
 if PY2:
     def is_nonstr_iter(v):
@@ -28,11 +31,10 @@ else:
 
 try:
     xrange = xrange
-except NameError: # pragma: no cover
+except NameError:  # pragma: no cover
     xrange = range
-
 
 try:
     from cPickle import loads, dumps, HIGHEST_PROTOCOL
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     from pickle import loads, dumps, HIGHEST_PROTOCOL

--- a/colander/compat.py
+++ b/colander/compat.py
@@ -4,7 +4,7 @@ import sys
 PY2 = sys.version_info[0] == 2
 PY3 = not PY2
 
-if PY2:  # pragma: no cover
+if PY2:
     string_types = (basestring,)
     text_type = unicode
 else:
@@ -20,7 +20,7 @@ def text_(s, encoding='latin-1', errors='strict'):
     return s  # pragma: no cover
 
 
-if PY2:  # pragma: no cover
+if PY2:
 
     def is_nonstr_iter(v):
         return hasattr(v, '__iter__')

--- a/colander/interfaces.py
+++ b/colander/interfaces.py
@@ -22,6 +22,7 @@ def Validator(node, value):
     raising a :class:`colander.Invalid` exception.
     """
 
+
 class Type(object):
     def serialize(self, node, appstruct):
         """
@@ -57,4 +58,3 @@ class Type(object):
         If the object cannot be deserialized for any reason, a
         :exc:`colander.Invalid` exception should be raised.
         """
-

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2,6 +2,7 @@
 import unittest
 from colander.compat import text_, text_type
 
+
 def invalid_exc(func, *arg, **kw):
     from colander import Invalid
     try:
@@ -9,7 +10,8 @@ def invalid_exc(func, *arg, **kw):
     except Invalid as e:
         return e
     else:
-        raise AssertionError('Invalid not raised') # pragma: no cover
+        raise AssertionError('Invalid not raised')  # pragma: no cover
+
 
 class TestInvalid(unittest.TestCase):
     def _makeOne(self, node, msg=None, val=None):
@@ -102,7 +104,7 @@ class TestInvalid(unittest.TestCase):
         validator1 = DummyValidator('validator1')
         validator2 = DummyValidator('validator2')
         validator = All(validator1, validator2)
-        exc1 =  self._makeOne(node1, 'exc1')
+        exc1 = self._makeOne(node1, 'exc1')
         exc1.pos = 1
         exc1['node3'] = 'message1'
         exc2 = self._makeOne(node2, 'exc2')
@@ -118,15 +120,19 @@ class TestInvalid(unittest.TestCase):
     def test_asdict_with_all_validator_functional(self):
         # see https://github.com/Pylons/colander/issues/2
         import colander as c
+
         class MySchema(c.MappingSchema):
             number1 = c.SchemaNode(c.Int(), validator=c.Range(min=1))
             number2 = c.SchemaNode(c.Int(), validator=c.Range(min=1))
+
         def validate_higher(node, val):
             if val['number1'] >= val['number2']:
                 raise c.Invalid(node, 'Number 1 must be lower than number 2')
+
         def validate_different(node, val):
             if val['number1'] == val['number2']:
                 raise c.Invalid(node, "They can't be the same, either")
+
         schema = MySchema(validator=c.All(validate_higher, validate_different))
         try:
             schema.deserialize(dict(number1=2, number2=2))
@@ -164,7 +170,7 @@ class TestInvalid(unittest.TestCase):
             result,
             "{'node1.node2.3': 'exc1; exc2; exc3', "
             "'node1.node4': 'exc1; exc4'}"
-            )
+        )
 
     def test___setitem__fails(self):
         node = DummySchemaNode(None)
@@ -198,6 +204,7 @@ class TestInvalid(unittest.TestCase):
         exc = self._makeOne(node, None)
         self.assertEqual(exc.messages(), [])
 
+
 class TestAll(unittest.TestCase):
     def _makeOne(self, validators):
         from colander import All
@@ -229,6 +236,7 @@ class TestAll(unittest.TestCase):
         exc = invalid_exc(validator, node, None)
         self.assertEqual(exc.children, [exc1, exc2])
 
+
 class TestAny(unittest.TestCase):
     def _makeOne(self, validators):
         from colander import Any
@@ -258,6 +266,7 @@ class TestAny(unittest.TestCase):
         validator = self._makeOne([validator1, validator2])
         self.assertEqual(validator(None, None), None)
 
+
 class TestFunction(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import Function
@@ -286,8 +295,10 @@ class TestFunction(unittest.TestCase):
         import warnings
         orig_warn = warnings.warn
         log = []
+
         def warn(message, category=None, stacklevel=1):
             log.append((message, category, stacklevel))
+
         try:
             # Monkey patching warn so that tests run quietly
             warnings.warn = warn
@@ -297,13 +308,14 @@ class TestFunction(unittest.TestCase):
         finally:
             warnings.warn = orig_warn
 
-
     def test_deprecated_message_warning(self):
         import warnings
         orig_warn = warnings.warn
         log = []
+
         def warn(message, category=None, stacklevel=1):
             log.append((message, category, stacklevel))
+
         try:
             # Monkey patching warn since catch_warnings context manager
             # is not working when running the full suite
@@ -346,6 +358,7 @@ class TestFunction(unittest.TestCase):
         validator = self._makeOne(lambda x: 'a' in x, 'msg')
         self.assertRaises(TypeError, validator, None, None)
 
+
 class TestRange(unittest.TestCase):
     def _makeOne(self, **kw):
         from colander import Range
@@ -387,6 +400,7 @@ class TestRange(unittest.TestCase):
         validator = self._makeOne(max=1, max_err='wrong')
         e = invalid_exc(validator, None, 2)
         self.assertEqual(e.msg, 'wrong')
+
 
 class TestRegex(unittest.TestCase):
     def _makeOne(self, pattern):
@@ -530,7 +544,7 @@ class TestContainsOnly(unittest.TestCase):
         self.assertEqual(
             e.msg.interpolate(),
             'One or more of the choices you made was not acceptable'
-            )
+        )
 
     def test_failure_with_custom_error_template(self):
         validator = self._makeOne([1])
@@ -538,6 +552,7 @@ class TestContainsOnly(unittest.TestCase):
         validator.err_template = _('${val}: ${choices}')
         e = invalid_exc(validator, None, [2])
         self.assertTrue('[2]' in e.msg.interpolate())
+
 
 class Test_luhnok(unittest.TestCase):
     def _callFUT(self, node, value):
@@ -563,6 +578,7 @@ class Test_luhnok(unittest.TestCase):
         val = '4111111111111111'
         self.assertFalse(self._callFUT(None, val))
 
+
 class Test_url_validator(unittest.TestCase):
     def _callFUT(self, val):
         from colander import url
@@ -577,6 +593,7 @@ class Test_url_validator(unittest.TestCase):
         val = 'not-a-url'
         from colander import Invalid
         self.assertRaises(Invalid, self._callFUT, val)
+
 
 class TestUUID(unittest.TestCase):
     def _callFUT(self, val):
@@ -629,6 +646,7 @@ class TestUUID(unittest.TestCase):
         from colander import Invalid
         self.assertRaises(Invalid, self._callFUT, val)
 
+
 class TestSchemaType(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import SchemaType
@@ -638,13 +656,13 @@ class TestSchemaType(unittest.TestCase):
         node = DummySchemaNode(None, name='node')
         typ = self._makeOne()
         result = typ.flatten(node, 'appstruct')
-        self.assertEqual(result, {'node':'appstruct'})
+        self.assertEqual(result, {'node': 'appstruct'})
 
     def test_flatten_listitem(self):
         node = DummySchemaNode(None, name='node')
         typ = self._makeOne()
         result = typ.flatten(node, 'appstruct', listitem=True)
-        self.assertEqual(result, {'':'appstruct'})
+        self.assertEqual(result, {'': 'appstruct'})
 
     def test_unflatten(self):
         node = DummySchemaNode(None, name='node')
@@ -666,6 +684,7 @@ class TestSchemaType(unittest.TestCase):
         typ = self._makeOne()
         self.assertEqual(typ.cstruct_children(None, None), [])
 
+
 class TestMapping(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import Mapping
@@ -679,7 +698,7 @@ class TestMapping(unittest.TestCase):
             self._makeOne('ignore')
             self._makeOne('raise')
             self._makeOne('preserve')
-        except ValueError as e: # pragma: no cover
+        except ValueError as e:  # pragma: no cover
             raise AssertionError(e)
 
     def test_deserialize_not_a_mapping(self):
@@ -723,36 +742,35 @@ class TestMapping(unittest.TestCase):
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
-        result = typ.deserialize(node, {'a':1})
-        self.assertEqual(result, {'a':1})
+        result = typ.deserialize(node, {'a': 1})
+        self.assertEqual(result, {'a': 1})
 
     def test_deserialize_unknown_raise(self):
         import colander
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne(unknown='raise')
-        e = invalid_exc(typ.deserialize, node, {'a':1, 'b':2})
+        e = invalid_exc(typ.deserialize, node, {'a': 1, 'b': 2})
         self.assertTrue(isinstance(e, colander.UnsupportedFields))
         self.assertEqual(e.fields, {'b': 2})
         self.assertEqual(e.msg.interpolate(),
                          "Unrecognized keys in mapping: \"{'b': 2}\"")
 
-
     def test_deserialize_unknown_preserve(self):
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne(unknown='preserve')
-        result = typ.deserialize(node, {'a':1, 'b':2})
-        self.assertEqual(result, {'a':1, 'b':2})
+        result = typ.deserialize(node, {'a': 1, 'b': 2})
+        self.assertEqual(result, {'a': 1, 'b': 2})
 
     def test_deserialize_subnodes_raise(self):
         node = DummySchemaNode(None)
         node.children = [
             DummySchemaNode(None, name='a', exc='Wrong 2'),
             DummySchemaNode(None, name='b', exc='Wrong 2'),
-            ]
+        ]
         typ = self._makeOne()
-        e = invalid_exc(typ.deserialize, node, {'a':1, 'b':2})
+        e = invalid_exc(typ.deserialize, node, {'a': 1, 'b': 2})
         self.assertEqual(e.msg, None)
         self.assertEqual(len(e.children), 2)
 
@@ -762,10 +780,10 @@ class TestMapping(unittest.TestCase):
         node.children = [
             DummySchemaNode(None, name='a'),
             DummySchemaNode(None, name='b', default='abc'),
-            ]
+        ]
         typ = self._makeOne()
-        result = typ.deserialize(node, {'a':1})
-        self.assertEqual(result, {'a':1, 'b':colander.null})
+        result = typ.deserialize(node, {'a': 1})
+        self.assertEqual(result, {'a': 1, 'b': colander.null})
 
     def test_serialize_null(self):
         import colander
@@ -792,17 +810,17 @@ class TestMapping(unittest.TestCase):
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
-        result = typ.serialize(node, {'a':1})
-        self.assertEqual(result, {'a':1})
+        result = typ.serialize(node, {'a': 1})
+        self.assertEqual(result, {'a': 1})
 
     def test_serialize_with_unknown(self):
         node = DummySchemaNode(None)
         node.children = [
             DummySchemaNode(None, name='a'),
-            ]
+        ]
         typ = self._makeOne()
-        result = typ.serialize(node, {'a':1, 'b':2})
-        self.assertEqual(result, {'a':1})
+        result = typ.serialize(node, {'a': 1, 'b': 2})
+        self.assertEqual(result, {'a': 1})
 
     def test_serialize_value_is_null(self):
         node = DummySchemaNode(None)
@@ -810,14 +828,14 @@ class TestMapping(unittest.TestCase):
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
         result = typ.serialize(node, null)
-        self.assertEqual(result, {'a':null})
+        self.assertEqual(result, {'a': null})
 
     def test_serialize_value_has_drop(self):
         from colander import drop
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
-        result = typ.serialize(node, {'a':drop})
+        result = typ.serialize(node, {'a': drop})
         self.assertEqual(result, {})
 
     def test_flatten(self):
@@ -827,9 +845,9 @@ class TestMapping(unittest.TestCase):
         node.children = [
             DummySchemaNode(int1, name='a'),
             DummySchemaNode(int2, name='b'),
-            ]
+        ]
         typ = self._makeOne()
-        result = typ.flatten(node, {'a':1, 'b':2})
+        result = typ.flatten(node, {'a': 1, 'b': 2})
         self.assertEqual(result, {'node.appstruct': 2})
 
     def test_flatten_listitem(self):
@@ -839,9 +857,9 @@ class TestMapping(unittest.TestCase):
         node.children = [
             DummySchemaNode(int1, name='a'),
             DummySchemaNode(int2, name='b'),
-            ]
+        ]
         typ = self._makeOne()
-        result = typ.flatten(node, {'a':1, 'b':2}, listitem=True)
+        result = typ.flatten(node, {'a': 1, 'b': 2}, listitem=True)
         self.assertEqual(result, {'appstruct': 2})
 
     def test_unflatten(self):
@@ -851,11 +869,13 @@ class TestMapping(unittest.TestCase):
         node.children = [
             DummySchemaNode(int1, name='a'),
             DummySchemaNode(int2, name='b'),
-            ]
+        ]
         typ = self._makeOne()
-        result = typ.unflatten(node,
+        result = typ.unflatten(
+            node,
             ['node', 'node.a', 'node.b'],
-            {'node': {'a':1, 'b':2}, 'node.a':1, 'node.b':2})
+            {'node': {'a': 1, 'b': 2}, 'node.a': 1, 'node.b': 2}
+        )
         self.assertEqual(result, {'a': 1, 'b': 2})
 
     def test_unflatten_nested(self):
@@ -874,15 +894,20 @@ class TestMapping(unittest.TestCase):
         node.children = [one, two]
         typ = self._makeOne()
         result = typ.unflatten(
-            node, ['node', 'node.one', 'node.one.a', 'node.one.b',
-                   'node.two', 'node.two.c', 'node.two.d'],
-            {'node': {'one': {'a': 1, 'b': 2}, 'two': {'c': 3, 'd': 4}},
-             'node.one': {'a': 1, 'b': 2},
-             'node.two': {'c': 3, 'd': 4},
-             'node.one.a': 1,
-             'node.one.b': 2,
-             'node.two.c': 3,
-             'node.two.d': 4,})
+            node, [
+                'node', 'node.one', 'node.one.a', 'node.one.b',
+                'node.two', 'node.two.c', 'node.two.d'
+            ],
+            {
+                'node': {'one': {'a': 1, 'b': 2}, 'two': {'c': 3, 'd': 4}},
+                'node.one': {'a': 1, 'b': 2},
+                'node.two': {'c': 3, 'd': 4},
+                'node.one.a': 1,
+                'node.one.b': 2,
+                'node.two.c': 3,
+                'node.two.d': 4,
+            }
+        )
         self.assertEqual(result, {
             'one': {'a': 1, 'b': 2}, 'two': {'c': 3, 'd': 4}})
 
@@ -921,8 +946,9 @@ class TestMapping(unittest.TestCase):
         node2 = DummySchemaNode(typ, name='node2')
         node3 = DummySchemaNode(typ, name='node3')
         node1.children = [node2, node3]
-        result = typ.cstruct_children(node1, {'node2':'abc'})
+        result = typ.cstruct_children(node1, {'node2': 'abc'})
         self.assertEqual(result, ['abc', null])
+
 
 class TestTuple(unittest.TestCase):
     def _makeOne(self):
@@ -962,24 +988,29 @@ class TestTuple(unittest.TestCase):
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
-        e = invalid_exc(typ.deserialize, node, ('a','b'))
-        self.assertEqual(e.msg.interpolate(),
-      "\"('a', 'b')\" has an incorrect number of elements (expected 1, was 2)")
+        e = invalid_exc(typ.deserialize, node, ('a', 'b'))
+        self.assertEqual(
+            e.msg.interpolate(),
+            "\"('a', 'b')\" has an incorrect number of "
+            "elements (expected 1, was 2)"
+        )
 
     def test_deserialize_toosmall(self):
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
         e = invalid_exc(typ.deserialize, node, ())
-        self.assertEqual(e.msg.interpolate(),
-           '"()" has an incorrect number of elements (expected 1, was 0)')
+        self.assertEqual(
+            e.msg.interpolate(),
+            '"()" has an incorrect number of elements (expected 1, was 0)'
+        )
 
     def test_deserialize_subnodes_raise(self):
         node = DummySchemaNode(None)
         node.children = [
             DummySchemaNode(None, name='a', exc='Wrong 2'),
             DummySchemaNode(None, name='b', exc='Wrong 2'),
-            ]
+        ]
         typ = self._makeOne()
         e = invalid_exc(typ.deserialize, node, ('1', '2'))
         self.assertEqual(e.msg, None)
@@ -1018,25 +1049,29 @@ class TestTuple(unittest.TestCase):
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
-        e = invalid_exc(typ.serialize, node, ('a','b'))
-        self.assertEqual(e.msg.interpolate(),
-     "\"('a', 'b')\" has an incorrect number of elements (expected 1, was 2)")
+        e = invalid_exc(typ.serialize, node, ('a', 'b'))
+        self.assertEqual(
+            e.msg.interpolate(),
+            "\"('a', 'b')\" has an incorrect number of "
+            "elements (expected 1, was 2)"
+        )
 
     def test_serialize_toosmall(self):
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
         e = invalid_exc(typ.serialize, node, ())
-        self.assertEqual(e.msg.interpolate(),
-           '"()" has an incorrect number of elements (expected 1, was 0)'
-           )
+        self.assertEqual(
+            e.msg.interpolate(),
+            '"()" has an incorrect number of elements (expected 1, was 0)'
+        )
 
     def test_serialize_subnodes_raise(self):
         node = DummySchemaNode(None)
         node.children = [
             DummySchemaNode(None, name='a', exc='Wrong 2'),
             DummySchemaNode(None, name='b', exc='Wrong 2'),
-            ]
+        ]
         typ = self._makeOne()
         e = invalid_exc(typ.serialize, node, ('1', '2'))
         self.assertEqual(e.msg, None)
@@ -1049,7 +1084,7 @@ class TestTuple(unittest.TestCase):
         node.children = [
             DummySchemaNode(int1, name='a'),
             DummySchemaNode(int2, name='b'),
-            ]
+        ]
         typ = self._makeOne()
         result = typ.flatten(node, (1, 2))
         self.assertEqual(result, {'node.appstruct': 2})
@@ -1061,7 +1096,7 @@ class TestTuple(unittest.TestCase):
         node.children = [
             DummySchemaNode(int1, name='a'),
             DummySchemaNode(int2, name='b'),
-            ]
+        ]
         typ = self._makeOne()
         result = typ.flatten(node, (1, 2), listitem=True)
         self.assertEqual(result, {'appstruct': 2})
@@ -1073,7 +1108,7 @@ class TestTuple(unittest.TestCase):
         node.children = [
             DummySchemaNode(int1, name='a'),
             DummySchemaNode(int2, name='b'),
-            ]
+        ]
         typ = self._makeOne()
         result = typ.unflatten(node, ['node', 'node.a', 'node.b'],
                                {'node': (1, 2), 'node.a': 1, 'node.b': 2})
@@ -1220,7 +1255,6 @@ class TestSet(unittest.TestCase):
         self.assertEqual(result, set(('a',)))
 
     def test_deserialize_empty_set(self):
-        import colander
         typ = self._makeOne()
         node = DummySchemaNode(typ)
         result = typ.deserialize(node, set())
@@ -1272,11 +1306,11 @@ class TestList(unittest.TestCase):
         self.assertEqual(result, ['a', 'z', 'b'])
 
     def test_deserialize_empty_set(self):
-        import colander
         typ = self._makeOne()
         node = DummySchemaNode(typ)
         result = typ.deserialize(node, ())
         self.assertEqual(result, [])
+
 
 class TestSequence(unittest.TestCase):
     def _makeOne(self, **kw):
@@ -1437,8 +1471,8 @@ class TestSequence(unittest.TestCase):
         ]
         typ = self._makeOne()
         result = typ.unflatten(node,
-            ['node.0', 'node.1',],
-            {'node.0': 'a', 'node.1': 'b'})
+                               ['node.0', 'node.1', ],
+                               {'node.0': 'a', 'node.1': 'b'})
         self.assertEqual(result, ['a', 'b'])
 
     def test_setvalue(self):
@@ -1473,6 +1507,7 @@ class TestSequence(unittest.TestCase):
         typ = self._makeOne()
         result = typ.cstruct_children(None, ['a'])
         self.assertEqual(result, SequenceItems(['a']))
+
 
 class TestString(unittest.TestCase):
     def _makeOne(self, encoding=None, allow_empty=False):
@@ -1603,6 +1638,7 @@ class TestString(unittest.TestCase):
         result = typ.serialize(node, 123)
         self.assertEqual(result, utf8)
 
+
 class TestInteger(unittest.TestCase):
     def _makeOne(self):
         from colander import Integer
@@ -1664,6 +1700,7 @@ class TestInteger(unittest.TestCase):
         result = typ.serialize(node, val)
         self.assertEqual(result, '0')
 
+
 class TestFloat(unittest.TestCase):
     def _makeOne(self):
         from colander import Float
@@ -1712,6 +1749,7 @@ class TestFloat(unittest.TestCase):
         typ = self._makeOne()
         result = typ.serialize(node, val)
         self.assertEqual(result, '1.0')
+
 
 class TestDecimal(unittest.TestCase):
     def _makeOne(self, quant=None, rounding=None, normalize=False):
@@ -1802,6 +1840,7 @@ class TestDecimal(unittest.TestCase):
         result = typ.serialize(node, val)
         self.assertEqual(result, '1.0')
 
+
 class TestMoney(unittest.TestCase):
     def _makeOne(self):
         from colander import Money
@@ -1821,6 +1860,7 @@ class TestMoney(unittest.TestCase):
         typ = self._makeOne()
         result = typ.deserialize(node, val)
         self.assertEqual(result, decimal.Decimal('1.01'))
+
 
 class TestBoolean(unittest.TestCase):
     def _makeOne(self):
@@ -1870,23 +1910,24 @@ class TestBoolean(unittest.TestCase):
         self.assertEqual(typ.serialize(node, None), 'false')
         self.assertEqual(typ.serialize(node, False), 'false')
 
+
 class TestBooleanCustomFalseReprs(unittest.TestCase):
     def _makeOne(self):
         from colander import Boolean
-        return Boolean(false_choices=('n','f'))
+        return Boolean(false_choices=('n', 'f'))
 
     def test_deserialize(self):
-        import colander
         typ = self._makeOne()
         node = DummySchemaNode(None)
         self.assertEqual(typ.deserialize(node, 'f'), False)
         self.assertEqual(typ.deserialize(node, 'N'), False)
         self.assertEqual(typ.deserialize(node, 'other'), True)
 
+
 class TestBooleanCustomFalseAndTrueReprs(unittest.TestCase):
     def _makeOne(self):
         from colander import Boolean
-        return Boolean(false_choices=('n','f'), true_choices=('y','t'))
+        return Boolean(false_choices=('n', 'f'), true_choices=('y', 't'))
 
     def test_deserialize(self):
         import colander
@@ -1898,10 +1939,11 @@ class TestBooleanCustomFalseAndTrueReprs(unittest.TestCase):
         self.assertEqual(typ.deserialize(node, 'y'), True)
         self.assertRaises(colander.Invalid, typ.deserialize, node, 'other')
         try:
-            _val = typ.deserialize(node, 'other')
+            typ.deserialize(node, 'other')
         except colander.Invalid as exc:
             self.assertEqual(exc.msg.mapping['false_choices'], "'n', 'f'")
             self.assertEqual(exc.msg.mapping['true_choices'], "'y', 't'")
+
 
 class TestBooleanCustomSerializations(unittest.TestCase):
     def _makeOne(self):
@@ -1916,6 +1958,7 @@ class TestBooleanCustomSerializations(unittest.TestCase):
         self.assertEqual(typ.serialize(node, None), 'no')
         self.assertEqual(typ.serialize(node, False), 'no')
 
+
 class TestGlobalObject(unittest.TestCase):
     def _makeOne(self, package=None):
         from colander import GlobalObject
@@ -1923,14 +1966,16 @@ class TestGlobalObject(unittest.TestCase):
 
     def test_zope_dottedname_style_resolve_absolute(self):
         typ = self._makeOne()
-        result = typ._zope_dottedname_style(None,
-            'colander.tests.test_colander.TestGlobalObject')
+        result = typ._zope_dottedname_style(
+            None,
+            'colander.tests.test_colander.TestGlobalObject'
+        )
         self.assertEqual(result, self.__class__)
 
     def test_zope_dottedname_style_irrresolveable_absolute(self):
         typ = self._makeOne()
         self.assertRaises(ImportError, typ._zope_dottedname_style, None,
-            'colander.tests.nonexisting')
+                          'colander.tests.nonexisting')
 
     def test__zope_dottedname_style_resolve_relative(self):
         import colander
@@ -1998,14 +2043,16 @@ class TestGlobalObject(unittest.TestCase):
 
     def test__pkg_resources_style_resolve_absolute(self):
         typ = self._makeOne()
-        result = typ._pkg_resources_style(None,
-            'colander.tests.test_colander:TestGlobalObject')
+        result = typ._pkg_resources_style(
+            None,
+            'colander.tests.test_colander:TestGlobalObject'
+        )
         self.assertEqual(result, self.__class__)
 
     def test__pkg_resources_style_irrresolveable_absolute(self):
         typ = self._makeOne()
         self.assertRaises(ImportError, typ._pkg_resources_style, None,
-            'colander.tests.test_colander:nonexisting')
+                          'colander.tests.test_colander:nonexisting')
 
     def test__pkg_resources_style_resolve_relative_startswith_colon(self):
         import colander.tests
@@ -2096,7 +2143,7 @@ class TestGlobalObject(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.serialize(node, colander.tests)
         self.assertEqual(result, 'colander.tests')
-        
+
         from colander import tests
         typ = self._makeOne()
         node = DummySchemaNode(None)
@@ -2108,14 +2155,16 @@ class TestGlobalObject(unittest.TestCase):
         typ = self._makeOne()
         node = DummySchemaNode(None)
         result = typ.serialize(node, cls)
-        self.assertEqual(result, 'colander.tests.test_colander.TestGlobalObject')
+        self.assertEqual(
+            result, 'colander.tests.test_colander.TestGlobalObject'
+        )
 
     def test_deserialize_class_ok(self):
         import colander
         names = (
-                 'colander.tests.test_colander.TestGlobalObject',
-                 '.tests.test_colander.TestGlobalObject',
-                 )
+            'colander.tests.test_colander.TestGlobalObject',
+            '.tests.test_colander.TestGlobalObject',
+        )
         typ = self._makeOne(colander)
         node = DummySchemaNode(None)
         for name in names:
@@ -2127,7 +2176,7 @@ class TestGlobalObject(unittest.TestCase):
         node = DummySchemaNode(None)
         for name in names:
             result = typ.deserialize(node, name)
-            self.assertEqual(result, self.__class__)         
+            self.assertEqual(result, self.__class__)
 
     def test_deserialize_class_fail(self):
         import colander
@@ -2136,15 +2185,18 @@ class TestGlobalObject(unittest.TestCase):
         typ = self._makeOne(colander)
         node = DummySchemaNode(None)
         for name in names:
-           e = invalid_exc(typ.deserialize, node, name)
-           self.assertEqual(e.msg.interpolate(),
-                            'The dotted name "{0}" cannot be imported'.format(name))
-           
+            e = invalid_exc(typ.deserialize, node, name)
+            self.assertEqual(
+                e.msg.interpolate(),
+                'The dotted name "{0}" cannot be imported'.format(name)
+            )
+
     def test_serialize_fail(self):
         typ = self._makeOne()
         node = DummySchemaNode(None)
         e = invalid_exc(typ.serialize, node, None)
         self.assertEqual(e.msg.interpolate(), '"None" has no __name__')
+
 
 class TestDateTime(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
@@ -2302,6 +2354,7 @@ class TestDateTime(unittest.TestCase):
         self.assertEqual(result.isoformat(), dt.isoformat())
         self.assertEqual(result.tzinfo, None)
 
+
 class TestDate(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import Date
@@ -2394,6 +2447,7 @@ class TestDate(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.deserialize(node, iso)
         self.assertEqual(result.isoformat(), dt.date().isoformat())
+
 
 class TestTime(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
@@ -2510,52 +2564,69 @@ class TestTime(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.deserialize(node, iso)
         self.assertEqual(result.isoformat(),
-                dt.time().isoformat().split('.')[0])
+                         dt.time().isoformat().split('.')[0])
+
 
 class TestEnum(unittest.TestCase):
     def _makeOne(self):
-        import colander, enum
+        import colander
+        import enum
+
         class DummyEnum(enum.Enum):
             red = 0
             green = 1
             blue = 2
+
         typ = colander.Enum(DummyEnum)
         return DummyEnum, typ
 
     def _makeOneIntVal(self):
-        import colander, enum
+        import colander
+        import enum
+
         class DummyEnum(enum.Enum):
             red = 0
             green = 1
             blue = 2
+
         typ = colander.Enum(DummyEnum, attr='value', typ=colander.Integer())
         return DummyEnum, typ
 
     def _makeOneStrVal(self):
-        import colander, enum
+        import colander
+        import enum
+
         class DummyEnum(enum.Enum):
             red = 'RED'
             green = 'GREEN'
             blue = 'BLUE'
+
         typ = colander.Enum(DummyEnum, attr='value', typ=colander.String())
         return DummyEnum, typ
 
     def test_non_unique_failure(self):
-        import colander, enum
+        import colander
+        import enum
+
         class NonUniqueEnum(enum.Enum):
             one = 1
             other = 1
+
         self.assertRaises(ValueError, colander.Enum, NonUniqueEnum,
                           attr='value', typ=colander.Integer())
 
     def test_non_unique_failure2(self):
-        import colander, enum
+        import colander
+        import enum
+
         class NonUniqueEnum(enum.Enum):
             some = (1, 1)
             other = (1, 2)
+
             def __init__(self, val0, val1):
                 self.val0 = val0
                 self.val1 = val1
+
         self.assertRaises(ValueError, colander.Enum, NonUniqueEnum,
                           attr='val0', typ=colander.Integer())
 
@@ -2634,6 +2705,7 @@ class TestEnum(unittest.TestCase):
         val = 'not a int'
         node = DummySchemaNode(None)
         invalid_exc(typ.deserialize, node, val)
+
 
 class TestSchemaNode(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
@@ -2724,11 +2796,14 @@ class TestSchemaNode(unittest.TestCase):
     def test_deserialize_with_preparer(self):
         from colander import Invalid
         typ = DummyType()
+
         def preparer(value):
-            return 'prepared_'+value
+            return 'prepared_' + value
+
         def validator(node, value):
             if not value.startswith('prepared'):
-                raise Invalid(node, 'not prepared') # pragma: no cover
+                raise Invalid(node, 'not prepared')  # pragma: no cover
+
         node = self._makeOne(typ,
                              preparer=preparer,
                              validator=validator)
@@ -2738,13 +2813,17 @@ class TestSchemaNode(unittest.TestCase):
     def test_deserialize_with_multiple_preparers(self):
         from colander import Invalid
         typ = DummyType()
+
         def preparer1(value):
-            return 'prepared1_'+value
+            return 'prepared1_' + value
+
         def preparer2(value):
-            return 'prepared2_'+value
+            return 'prepared2_' + value
+
         def validator(node, value):
             if not value.startswith('prepared2_prepared1'):
-                raise Invalid(node, 'not prepared') # pragma: no cover
+                raise Invalid(node, 'not prepared')  # pragma: no cover
+
         node = self._makeOne(typ,
                              preparer=[preparer1, preparer2],
                              validator=validator)
@@ -2754,9 +2833,11 @@ class TestSchemaNode(unittest.TestCase):
     def test_deserialize_preparer_before_missing_check(self):
         from colander import null
         typ = DummyType()
+
         def preparer(value):
             return null
-        node = self._makeOne(typ,preparer=preparer)
+
+        node = self._makeOne(typ, preparer=preparer)
         e = invalid_exc(node.deserialize, 1)
         self.assertEqual(e.msg, 'Required')
 
@@ -2772,10 +2853,13 @@ class TestSchemaNode(unittest.TestCase):
         from colander import deferred
         from colander import UnboundDeferredError
         typ = DummyType()
+
         def validator(node, kw):
             def _validate(node, value):
                 node.raise_invalid('Invalid')
+
             return _validate
+
         node = self._makeOne(typ, validator=deferred(validator))
         self.assertRaises(UnboundDeferredError, node.deserialize, None)
         self.assertRaises(Invalid, node.bind(foo='foo').deserialize, None)
@@ -2955,9 +3039,11 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_clone_with_modified_schema_instance(self):
         import colander
+
         class Schema(colander.MappingSchema):
             n1 = colander.SchemaNode(colander.String())
             n2 = colander.SchemaNode(colander.String())
+
         def compare_children(schema, cloned):
             # children of the clone must match the cloned node's children and
             # have to be clones themselves.
@@ -2967,6 +3053,7 @@ class TestSchemaNode(unittest.TestCase):
                 for name in child.__dict__.keys():
                     self.assertEqual(getattr(child, name),
                                      getattr(child_clone, name))
+
         # add a child node before cloning
         schema = Schema()
         schema.add(colander.SchemaNode(colander.String(), name='n3'))
@@ -2982,8 +3069,10 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_clone_mapping_references(self):
         import colander
+
         class Schema(colander.MappingSchema):
             n1 = colander.SchemaNode(colander.Mapping(unknown='preserve'))
+
         foo = {
             "n1": {
                 "bar": {
@@ -2999,10 +3088,12 @@ class TestSchemaNode(unittest.TestCase):
         from colander import deferred
         inner_typ = DummyType()
         outer_typ = DummyType()
+
         def dv(node, kw):
             self.assertTrue(node.name in ['outer', 'inner'])
             self.assertTrue('a' in kw)
             return '123'
+
         dv = deferred(dv)
         outer_node = self._makeOne(outer_typ, name='outer', missing=dv)
         inner_node = self._makeOne(inner_typ, name='inner', validator=dv,
@@ -3020,14 +3111,18 @@ class TestSchemaNode(unittest.TestCase):
         from colander import deferred
         inner_typ = DummyType()
         outer_typ = DummyType()
+
         def dv(node, kw):
             self.assertTrue(node.name in ['outer', 'inner'])
             self.assertTrue('a' in kw)
             return '123'
+
         dv = deferred(dv)
+
         def remove_inner(node, kw):
-            self.assertEqual(kw, {'a':1})
+            self.assertEqual(kw, {'a': 1})
             del node['inner']
+
         outer_node = self._makeOne(outer_typ, name='outer', missing=dv,
                                    after_bind=remove_inner)
         inner_node = self._makeOne(inner_typ, name='inner', validator=dv,
@@ -3042,12 +3137,14 @@ class TestSchemaNode(unittest.TestCase):
     def test_declarative_name_reassignment(self):
         # see https://github.com/Pylons/colander/issues/39
         import colander
+
         class FnordSchema(colander.Schema):
             fnord = colander.SchemaNode(
                 colander.Sequence(),
                 colander.SchemaNode(colander.Integer(), name=''),
                 name="fnord[]"
-                )
+            )
+
         schema = FnordSchema()
         self.assertEqual(schema['fnord[]'].name, 'fnord[]')
 
@@ -3072,68 +3169,85 @@ class TestSchemaNode(unittest.TestCase):
         node = self._makeOne(typ)
         self.assertRaises(colander.Invalid, node.raise_invalid, 'Wrong')
 
+
 class TestSchemaNodeSubclassing(unittest.TestCase):
     def test_subclass_uses_validator_method(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Int
             name = 'my'
+
             def validator(self, node, cstruct):
                 if cstruct > 10:
                     self.raise_invalid('Wrong')
+
         node = MyNode()
         self.assertRaises(colander.Invalid, node.deserialize, 20)
 
     def test_subclass_uses_missing(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Int
             name = 'my'
             missing = 10
+
         node = MyNode()
         result = node.deserialize(colander.null)
         self.assertEqual(result, 10)
 
     def test_subclass_uses_title(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Int
             title = 'some title'
+
         node = MyNode(name='my')
         self.assertEqual(node.title, 'some title')
 
     def test_subclass_title_overwritten_by_constructor(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Int
             title = 'some title'
+
         node = MyNode(name='my', title='other title')
         self.assertEqual(node.title, 'other title')
 
     def test_subelement_title_not_overwritten(self):
         import colander
+
         class SampleNode(colander.SchemaNode):
             schema_type = colander.String
             title = 'Some Title'
+
         class SampleSchema(colander.Schema):
             node = SampleNode()
+
         schema = SampleSchema()
         self.assertEqual('Some Title', schema.children[0].title)
 
     def test_subclass_value_overridden_by_constructor(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Int
             name = 'my'
             missing = 10
+
         node = MyNode(missing=5)
         result = node.deserialize(colander.null)
         self.assertEqual(result, 5)
 
     def test_method_values_can_rely_on_binding(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Int
+
             def amethod(self):
                 return self.bindings['request']
 
@@ -3143,8 +3257,10 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
 
     def test_nonmethod_values_can_rely_on_after_bind(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Int
+
             def after_bind(self, node, kw):
                 self.missing = kw['missing']
 
@@ -3154,12 +3270,15 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
 
     def test_deferred_methods_dont_quite_work_yet(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Int
+
             @colander.deferred
-            def avalidator(self, node, kw): # pragma: no cover
+            def avalidator(self, node, kw):  # pragma: no cover
                 def _avalidator(node, cstruct):
                     self.raise_invalid('Foo')
+
                 return _avalidator
 
         node = MyNode()
@@ -3167,8 +3286,10 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
 
     def test_nonmethod_values_can_be_deferred_though(self):
         import colander
+
         def _missing(node, kw):
             return 10
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Int
             missing = colander.deferred(_missing)
@@ -3179,8 +3300,10 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
 
     def test_functions_can_be_deferred(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Int
+
             @colander.deferred
             def missing(node, kw):
                 return 10
@@ -3191,6 +3314,7 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
 
     def test_nodes_can_be_deffered(self):
         import colander
+
         class MySchema(colander.MappingSchema):
             @colander.deferred
             def child(node, kw):
@@ -3202,54 +3326,65 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
 
     def test_schema_child_names_conflict_with_value_names_notused(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Mapping
             title = colander.SchemaNode(
                 colander.String(),
-                )
+            )
+
         node = MyNode()
         self.assertEqual(node.title, '')
 
     def test_schema_child_names_conflict_with_value_names_used(self):
         import colander
+
         doesntmatter = colander.SchemaNode(
             colander.String(),
             name='name',
-            )
+        )
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Mapping
             name = 'fred'
             wontmatter = doesntmatter
+
         node = MyNode()
         self.assertEqual(node.name, 'fred')
         self.assertEqual(node['name'], doesntmatter)
 
     def test_schema_child_names_conflict_with_value_names_in_superclass(self):
         import colander
+
         doesntmatter = colander.SchemaNode(
             colander.String(),
             name='name',
-            )
+        )
         _name = colander.SchemaNode(
             colander.String(),
-            )
+        )
+
         class MyNode(colander.SchemaNode):
             schema_type = colander.Mapping
             name = 'fred'
             wontmatter = doesntmatter
+
         class AnotherNode(MyNode):
             name = _name
+
         node = AnotherNode()
         self.assertEqual(node.name, 'fred')
         self.assertEqual(node['name'], _name)
 
     def test_schema_child_names_conflict_with_value_names_in_subclass(self):
         import colander
+
         class MyNode(colander.SchemaNode):
             name = colander.SchemaNode(
                 colander.String(),
                 id='name',
-                )
+            )
+
         class AnotherNode(MyNode):
             schema_type = colander.Mapping
             name = 'fred'
@@ -3257,221 +3392,230 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
                 colander.String(),
                 name='name',
                 id='doesntmatter',
-                )
+            )
+
         node = AnotherNode()
         self.assertEqual(node.name, 'fred')
         self.assertEqual(node['name'].id, 'doesntmatter')
 
+
 class TestMappingSchemaInheritance(unittest.TestCase):
     def test_single_inheritance(self):
         import colander
+
         class Friend(colander.Schema):
             rank = colander.SchemaNode(
                 colander.Int(),
                 id='rank',
-                )
+            )
             name = colander.SchemaNode(
                 colander.String(),
                 id='name'
-                )
+            )
             serial = colander.SchemaNode(
                 colander.Bool(),
                 id='serial2',
-                )
+            )
 
         class SpecialFriend(Friend):
             iwannacomefirst = colander.SchemaNode(
                 colander.Int(),
                 id='iwannacomefirst2',
-                )
+            )
 
         class SuperSpecialFriend(SpecialFriend):
             iwannacomefirst = colander.SchemaNode(
                 colander.String(),
                 id='iwannacomefirst1',
-                )
+            )
             another = colander.SchemaNode(
                 colander.String(),
                 id='another',
-                )
+            )
             serial = colander.SchemaNode(
                 colander.Int(),
                 id='serial1',
-                )
+            )
 
         inst = SuperSpecialFriend()
         self.assertEqual(
-            [ x.id for x in inst.children],
+            [x.id for x in inst.children],
             [
                 'rank',
                 'name',
                 'serial1',
                 'iwannacomefirst1',
                 'another',
-             ]
-            )
+            ]
+        )
 
     def test_single_inheritance_with_insert_before(self):
         import colander
+
         class Friend(colander.Schema):
             rank = colander.SchemaNode(
                 colander.Int(),
                 id='rank',
-                )
+            )
             name = colander.SchemaNode(
                 colander.String(),
                 id='name'
-                )
+            )
             serial = colander.SchemaNode(
                 colander.Bool(),
                 insert_before='name',
                 id='serial2',
-                )
+            )
 
         class SpecialFriend(Friend):
             iwannacomefirst = colander.SchemaNode(
                 colander.Int(),
                 id='iwannacomefirst2',
-                )
+            )
 
         class SuperSpecialFriend(SpecialFriend):
             iwannacomefirst = colander.SchemaNode(
                 colander.String(),
                 insert_before='rank',
                 id='iwannacomefirst1',
-                )
+            )
             another = colander.SchemaNode(
                 colander.String(),
                 id='another',
-                )
+            )
             serial = colander.SchemaNode(
                 colander.Int(),
                 id='serial1',
-                )
+            )
 
         inst = SuperSpecialFriend()
         self.assertEqual(
-            [ x.id for x in inst.children],
+            [x.id for x in inst.children],
             [
                 'iwannacomefirst1',
                 'rank',
                 'serial1',
                 'name',
                 'another',
-             ]
-            )
+            ]
+        )
 
     def test_single_inheritance2(self):
         import colander
+
         class One(colander.Schema):
             a = colander.SchemaNode(
                 colander.Int(),
                 id='a1',
-                )
+            )
             b = colander.SchemaNode(
                 colander.Int(),
                 id='b1',
-                )
+            )
             d = colander.SchemaNode(
                 colander.Int(),
                 id='d1',
-                )
+            )
 
         class Two(One):
             a = colander.SchemaNode(
                 colander.String(),
                 id='a2',
-                )
+            )
             c = colander.SchemaNode(
                 colander.String(),
                 id='c2',
-                )
+            )
             e = colander.SchemaNode(
                 colander.String(),
                 id='e2',
-                )
+            )
 
         class Three(Two):
             b = colander.SchemaNode(
                 colander.Bool(),
                 id='b3',
-                )
+            )
             d = colander.SchemaNode(
                 colander.Bool(),
                 id='d3',
-                )
+            )
             f = colander.SchemaNode(
                 colander.Bool(),
                 id='f3',
-                )
+            )
 
         inst = Three()
         c = inst.children
         self.assertEqual(len(c), 6)
-        result = [ x.id for x in c ]
+        result = [x.id for x in c]
         self.assertEqual(result, ['a2', 'b3', 'd3', 'c2', 'e2', 'f3'])
 
     def test_multiple_inheritance(self):
         import colander
+
         class One(colander.Schema):
             a = colander.SchemaNode(
                 colander.Int(),
                 id='a1',
-                )
+            )
             b = colander.SchemaNode(
                 colander.Int(),
                 id='b1',
-                )
+            )
             d = colander.SchemaNode(
                 colander.Int(),
                 id='d1',
-                )
+            )
 
         class Two(colander.Schema):
             a = colander.SchemaNode(
                 colander.String(),
                 id='a2',
-                )
+            )
             c = colander.SchemaNode(
                 colander.String(),
                 id='c2',
-                )
+            )
             e = colander.SchemaNode(
                 colander.String(),
                 id='e2',
-                )
+            )
 
         class Three(Two, One):
             b = colander.SchemaNode(
                 colander.Bool(),
                 id='b3',
-                )
+            )
             d = colander.SchemaNode(
                 colander.Bool(),
                 id='d3',
-                )
+            )
             f = colander.SchemaNode(
                 colander.Bool(),
                 id='f3',
-                )
+            )
 
         inst = Three()
         c = inst.children
         self.assertEqual(len(c), 6)
-        result = [ x.id for x in c ]
+        result = [x.id for x in c]
         self.assertEqual(result, ['a2', 'b3', 'd3', 'c2', 'e2', 'f3'])
 
     def test_insert_before_failure(self):
         import colander
+
         class One(colander.Schema):
             a = colander.SchemaNode(
                 colander.Int(),
-                )
+            )
             b = colander.SchemaNode(
                 colander.Int(),
                 insert_before='c'
-                )
+            )
+
         self.assertRaises(KeyError, One)
+
 
 class TestDeferred(unittest.TestCase):
     def _makeOne(self, wrapped):
@@ -3486,43 +3630,48 @@ class TestDeferred(unittest.TestCase):
     def test___call__(self):
         n = object()
         k = object()
+
         def wrapped(node, kw):
             self.assertEqual(node, n)
             self.assertEqual(kw, k)
             return 'abc'
+
         inst = self._makeOne(wrapped)
-        result= inst(n, k)
+        result = inst(n, k)
         self.assertEqual(result, 'abc')
 
     def test_retain_func_details(self):
         def wrapped_func(node, kw):
             """Can you hear me now?"""
             pass  # pragma: no cover
+
         inst = self._makeOne(wrapped_func)
         self.assertEqual(inst.__doc__, 'Can you hear me now?')
         self.assertEqual(inst.__name__, 'wrapped_func')
 
     def test_w_callable_instance_no_name(self):
-        from colander import deferred
         class Wrapped(object):
             """CLASS"""
+
             def __call__(self, node, kw):
                 """METHOD"""
-                pass # pragma: no cover
+                pass  # pragma: no cover
+
         wrapped = Wrapped()
         inst = self._makeOne(wrapped)
         self.assertEqual(inst.__doc__, wrapped.__doc__)
         self.assertFalse('__name__' in inst.__dict__)
 
     def test_w_callable_instance_no_name_or_doc(self):
-        from colander import deferred
         class Wrapped(object):
             def __call__(self, node, kw):
-                pass # pragma: no cover
+                pass  # pragma: no cover
+
         wrapped = Wrapped()
         inst = self._makeOne(wrapped)
         self.assertEqual(inst.__doc__, None)
         self.assertFalse('__name__' in inst.__dict__)
+
 
 class TestSchema(unittest.TestCase):
     def test_alias(self):
@@ -3532,9 +3681,11 @@ class TestSchema(unittest.TestCase):
 
     def test_it(self):
         import colander
+
         class MySchema(colander.Schema):
             thing_a = colander.SchemaNode(colander.String())
             thing2 = colander.SchemaNode(colander.String(), title='bar')
+
         node = MySchema(default='abc')
         self.assertTrue(hasattr(node, '_order'))
         self.assertEqual(node.default, 'abc')
@@ -3546,11 +3697,13 @@ class TestSchema(unittest.TestCase):
 
     def test_title_munging(self):
         import colander
+
         class MySchema(colander.Schema):
             thing1 = colander.SchemaNode(colander.String())
             thing2 = colander.SchemaNode(colander.String(), title=None)
             thing3 = colander.SchemaNode(colander.String(), title='')
             thing4 = colander.SchemaNode(colander.String(), title='thing2')
+
         node = MySchema()
         self.assertEqual(node.children[0].title, 'Thing1')
         self.assertEqual(node.children[1].title, None)
@@ -3559,9 +3712,11 @@ class TestSchema(unittest.TestCase):
 
     def test_deserialize_drop(self):
         import colander
+
         class MySchema(colander.Schema):
             a = colander.SchemaNode(colander.String())
             b = colander.SchemaNode(colander.String(), missing=colander.drop)
+
         node = MySchema()
         expected = {'a': 'test'}
         result = node.deserialize(expected)
@@ -3569,9 +3724,11 @@ class TestSchema(unittest.TestCase):
 
     def test_serialize_drop_default(self):
         import colander
+
         class MySchema(colander.Schema):
             a = colander.SchemaNode(colander.String())
             b = colander.SchemaNode(colander.String(), default=colander.drop)
+
         node = MySchema()
         expected = {'a': 'foo'}
         result = node.serialize(expected)
@@ -3587,20 +3744,25 @@ class TestSchema(unittest.TestCase):
     def test_schema_with_cloned_nodes(self):
         import colander
         test_node = colander.SchemaNode(colander.String())
+
         class TestSchema(colander.Schema):
             a = test_node.clone()
             b = test_node.clone()
+
         node = TestSchema()
         expected = {'a': 'foo', 'b': 'bar'}
         result = node.serialize(expected)
         self.assertEqual(result, expected)
 
+
 class TestSequenceSchema(unittest.TestCase):
     def test_succeed(self):
         import colander
         _inner = colander.SchemaNode(colander.String())
+
         class MySchema(colander.SequenceSchema):
             inner = _inner
+
         node = MySchema()
         self.assertTrue(hasattr(node, '_order'))
         self.assertTrue(isinstance(node, colander.SchemaNode))
@@ -3611,9 +3773,11 @@ class TestSequenceSchema(unittest.TestCase):
         import colander
         thingnode = colander.SchemaNode(colander.String())
         thingnode2 = colander.SchemaNode(colander.String())
+
         class MySchema(colander.SequenceSchema):
             thing = thingnode
             thing2 = thingnode2
+
         e = invalid_exc(MySchema)
         self.assertEqual(
             e.msg,
@@ -3621,8 +3785,10 @@ class TestSequenceSchema(unittest.TestCase):
 
     def test_fail_toofew(self):
         import colander
+
         class MySchema(colander.SequenceSchema):
             pass
+
         e = invalid_exc(MySchema)
         self.assertEqual(
             e.msg,
@@ -3637,8 +3803,10 @@ class TestSequenceSchema(unittest.TestCase):
 
     def test_deserialize_drop(self):
         import colander
+
         class MySchema(colander.SequenceSchema):
             a = colander.SchemaNode(colander.String(), missing=colander.drop)
+
         node = MySchema()
         result = node.deserialize([None])
         self.assertEqual(result, [])
@@ -3647,8 +3815,10 @@ class TestSequenceSchema(unittest.TestCase):
 
     def test_serialize_drop_default(self):
         import colander
+
         class MySchema(colander.SequenceSchema):
             a = colander.SchemaNode(colander.String(), default=colander.drop)
+
         node = MySchema()
         result = node.serialize([colander.null])
         self.assertEqual(result, [])
@@ -3664,11 +3834,14 @@ class TestSequenceSchema(unittest.TestCase):
         self.assertIsNot(schema.children[0], clone.children[0])
         self.assertEqual(schema.children[0].name, clone.children[0].name)
 
+
 class TestTupleSchema(unittest.TestCase):
     def test_it(self):
         import colander
+
         class MySchema(colander.TupleSchema):
             thing = colander.SchemaNode(colander.String())
+
         node = MySchema()
         self.assertTrue(hasattr(node, '_order'))
         self.assertTrue(isinstance(node, colander.SchemaNode))
@@ -3682,16 +3855,17 @@ class TestTupleSchema(unittest.TestCase):
         self.assertEqual(schema.schema_type, colander.Tuple)
         self.assertEqual(schema.children[0], node)
 
+
 class TestFunctional(object):
     def test_deserialize_ok(self):
         import colander.tests
         data = {
-            'int':'10',
-            'ob':'colander.tests',
-            'seq':[('1', 's'),('2', 's'), ('3', 's'), ('4', 's')],
-            'seq2':[{'key':'1', 'key2':'2'}, {'key':'3', 'key2':'4'}],
-            'tup':('1', 's'),
-            }
+            'int': '10',
+            'ob': 'colander.tests',
+            'seq': [('1', 's'), ('2', 's'), ('3', 's'), ('4', 's')],
+            'seq2': [{'key': '1', 'key2': '2'}, {'key': '3', 'key2': '4'}],
+            'tup': ('1', 's'),
+        }
         schema = self._makeSchema()
         result = schema.deserialize(data)
         self.assertEqual(result['int'], 10)
@@ -3699,18 +3873,18 @@ class TestFunctional(object):
         self.assertEqual(result['seq'],
                          [(1, 's'), (2, 's'), (3, 's'), (4, 's')])
         self.assertEqual(result['seq2'],
-                         [{'key':1, 'key2':2}, {'key':3, 'key2':4}])
+                         [{'key': 1, 'key2': 2}, {'key': 3, 'key2': 4}])
         self.assertEqual(result['tup'], (1, 's'))
 
     def test_flatten_ok(self):
         import colander
         appstruct = {
-            'int':10,
-            'ob':colander.tests,
-            'seq':[(1, 's'),(2, 's'), (3, 's'), (4, 's')],
-            'seq2':[{'key':1, 'key2':2}, {'key':3, 'key2':4}],
-            'tup':(1, 's'),
-            }
+            'int': 10,
+            'ob': colander.tests,
+            'seq': [(1, 's'), (2, 's'), (3, 's'), (4, 's')],
+            'seq2': [{'key': 1, 'key2': 2}, {'key': 3, 'key2': 4}],
+            'tup': (1, 's'),
+        }
         schema = self._makeSchema()
         result = schema.flatten(appstruct)
 
@@ -3741,12 +3915,12 @@ class TestFunctional(object):
     def test_flatten_mapping_has_no_name(self):
         import colander
         appstruct = {
-            'int':10,
-            'ob':colander.tests,
-            'seq':[(1, 's'),(2, 's'), (3, 's'), (4, 's')],
-            'seq2':[{'key':1, 'key2':2}, {'key':3, 'key2':4}],
-            'tup':(1, 's'),
-            }
+            'int': 10,
+            'ob': colander.tests,
+            'seq': [(1, 's'), (2, 's'), (3, 's'), (4, 's')],
+            'seq2': [{'key': 1, 'key2': 2}, {'key': 3, 'key2': 4}],
+            'tup': (1, 's'),
+        }
         schema = self._makeSchema(name='')
         result = schema.flatten(appstruct)
 
@@ -3798,12 +3972,12 @@ class TestFunctional(object):
         result = schema.unflatten(fstruct)
 
         expected = {
-            'int':10,
-            'ob':colander.tests,
-            'seq':[(1, 's'),(2, 's'), (3, 's'), (4, 's')],
-            'seq2':[{'key':1, 'key2':2}, {'key':3, 'key2':4}],
-            'tup':(1, 's'),
-            }
+            'int': 10,
+            'ob': colander.tests,
+            'seq': [(1, 's'), (2, 's'), (3, 's'), (4, 's')],
+            'seq2': [{'key': 1, 'key2': 2}, {'key': 3, 'key2': 4}],
+            'tup': (1, 's'),
+        }
 
         for k, v in expected.items():
             self.assertEqual(result[k], v)
@@ -3834,12 +4008,12 @@ class TestFunctional(object):
         result = schema.unflatten(fstruct)
 
         expected = {
-            'int':10,
-            'ob':colander.tests,
-            'seq':[(1, 's'),(2, 's'), (3, 's'), (4, 's')],
-            'seq2':[{'key':1, 'key2':2}, {'key':3, 'key2':4}],
-            'tup':(1, 's'),
-            }
+            'int': 10,
+            'ob': colander.tests,
+            'seq': [(1, 's'), (2, 's'), (3, 's'), (4, 's')],
+            'seq2': [{'key': 1, 'key2': 2}, {'key': 3, 'key2': 4}],
+            'tup': (1, 's'),
+        }
 
         for k, v in expected.items():
             self.assertEqual(result[k], v)
@@ -3849,12 +4023,12 @@ class TestFunctional(object):
     def test_flatten_unflatten_roundtrip(self):
         import colander
         appstruct = {
-            'int':10,
-            'ob':colander.tests,
-            'seq':[(1, 's'),(2, 's'), (3, 's'), (4, 's')],
-            'seq2':[{'key':1, 'key2':2}, {'key':3, 'key2':4}],
-            'tup':(1, 's'),
-            }
+            'int': 10,
+            'ob': colander.tests,
+            'seq': [(1, 's'), (2, 's'), (3, 's'), (4, 's')],
+            'seq2': [{'key': 1, 'key2': 2}, {'key': 3, 'key2': 4}],
+            'tup': (1, 's'),
+        }
         schema = self._makeSchema(name='')
         self.assertEqual(
             schema.unflatten(schema.flatten(appstruct)),
@@ -3863,28 +4037,28 @@ class TestFunctional(object):
     def test_set_value(self):
         import colander
         appstruct = {
-            'int':10,
-            'ob':colander.tests,
-            'seq':[(1, 's'),(2, 's'), (3, 's'), (4, 's')],
-            'seq2':[{'key':1, 'key2':2}, {'key':3, 'key2':4}],
-            'tup':(1, 's'),
-            }
+            'int': 10,
+            'ob': colander.tests,
+            'seq': [(1, 's'), (2, 's'), (3, 's'), (4, 's')],
+            'seq2': [{'key': 1, 'key2': 2}, {'key': 3, 'key2': 4}],
+            'tup': (1, 's'),
+        }
         schema = self._makeSchema()
         schema.set_value(appstruct, 'seq2.1.key', 6)
-        self.assertEqual(appstruct['seq2'][1], {'key':6, 'key2':4})
+        self.assertEqual(appstruct['seq2'][1], {'key': 6, 'key2': 4})
 
     def test_get_value(self):
         import colander
         appstruct = {
-            'int':10,
-            'ob':colander.tests,
-            'seq':[(1, 's'),(2, 's'), (3, 's'), (4, 's')],
-            'seq2':[{'key':1, 'key2':2}, {'key':3, 'key2':4}],
-            'tup':(1, 's'),
-            }
+            'int': 10,
+            'ob': colander.tests,
+            'seq': [(1, 's'), (2, 's'), (3, 's'), (4, 's')],
+            'seq2': [{'key': 1, 'key2': 2}, {'key': 3, 'key2': 4}],
+            'tup': (1, 's'),
+        }
         schema = self._makeSchema()
         self.assertEqual(schema.get_value(appstruct, 'seq'),
-                         [(1, 's'),(2, 's'), (3, 's'), (4, 's')])
+                         [(1, 's'), (2, 's'), (3, 's'), (4, 's')])
         self.assertEqual(schema.get_value(appstruct, 'seq2.1.key'), 3)
 
     def test_invalid_asdict(self):
@@ -3902,12 +4076,12 @@ class TestFunctional(object):
             'schema.seq2.1.key2': '"i" is not a number',
             'schema.tup.0': '"s" is not a number'}
         data = {
-            'int':'20',
-            'ob':'no.way.this.exists',
-            'seq':[('q', 's'),('w', 's'), ('e', 's'), ('r', 's')],
-            'seq2':[{'key':'t', 'key2':'y'}, {'key':'u', 'key2':'i'}],
-            'tup':('s', 's'),
-            }
+            'int': '20',
+            'ob': 'no.way.this.exists',
+            'seq': [('q', 's'), ('w', 's'), ('e', 's'), ('r', 's')],
+            'seq2': [{'key': 't', 'key2': 'y'}, {'key': 'u', 'key2': 'i'}],
+            'tup': ('s', 's'),
+        }
         schema = self._makeSchema()
         e = invalid_exc(schema.deserialize, data)
         errors = e.asdict()
@@ -3933,7 +4107,7 @@ class TestFunctional(object):
             'int': '20',
             'ob': 'no.way.this.exists',
             'seq': [('q', 's'), ('w', 's'), ('e', 's'), ('r', 's')],
-            'seq2': [{'key': 't', 'key2': 'y'}, {'key':'u', 'key2':'i'}],
+            'seq2': [{'key': 't', 'key2': 'y'}, {'key': 'u', 'key2': 'i'}],
             'tup': ('s', 's'),
         }
         schema = self._makeSchema()
@@ -3955,31 +4129,31 @@ class TestImperative(unittest.TestCase, TestFunctional):
             colander.Integer(),
             name='int',
             validator=colander.Range(0, 10)
-            )
+        )
 
         ob = colander.SchemaNode(
             colander.GlobalObject(package=colander),
             name='ob',
-            )
+        )
 
         tup = colander.SchemaNode(
             colander.Tuple(),
             colander.SchemaNode(
                 colander.Integer(),
                 name='tupint',
-                ),
+            ),
             colander.SchemaNode(
                 colander.String(),
                 name='tupstring',
-                ),
+            ),
             name='tup',
-            )
+        )
 
         seq = colander.SchemaNode(
             colander.Sequence(),
             tup,
             name='seq',
-            )
+        )
 
         seq2 = colander.SchemaNode(
             colander.Sequence(),
@@ -3988,15 +4162,15 @@ class TestImperative(unittest.TestCase, TestFunctional):
                 colander.SchemaNode(
                     colander.Integer(),
                     name='key',
-                    ),
+                ),
                 colander.SchemaNode(
                     colander.Integer(),
                     name='key2',
-                    ),
-                name='mapping',
                 ),
+                name='mapping',
+            ),
             name='seq2',
-            )
+        )
 
         schema = colander.SchemaNode(
             colander.Mapping(),
@@ -4009,10 +4183,10 @@ class TestImperative(unittest.TestCase, TestFunctional):
 
         return schema
 
+
 class TestDeclarative(unittest.TestCase, TestFunctional):
 
     def _makeSchema(self, name='schema'):
-
         import colander
 
         class TupleSchema(colander.TupleSchema):
@@ -4031,7 +4205,7 @@ class TestDeclarative(unittest.TestCase, TestFunctional):
 
         class MainSchema(colander.MappingSchema):
             int = colander.SchemaNode(colander.Int(),
-                                     validator=colander.Range(0, 10))
+                                      validator=colander.Range(0, 10))
             ob = colander.SchemaNode(colander.GlobalObject(package=colander))
             seq = SequenceOne()
             tup = TupleSchema()
@@ -4040,10 +4214,10 @@ class TestDeclarative(unittest.TestCase, TestFunctional):
         schema = MainSchema(name=name)
         return schema
 
+
 class TestUltraDeclarative(unittest.TestCase, TestFunctional):
 
     def _makeSchema(self, name='schema'):
-
         import colander
 
         class IntSchema(colander.SchemaNode):
@@ -4085,10 +4259,10 @@ class TestUltraDeclarative(unittest.TestCase, TestFunctional):
         schema = MainSchema()
         return schema
 
+
 class TestDeclarativeWithInstantiate(unittest.TestCase, TestFunctional):
 
     def _makeSchema(self, name='schema'):
-
         import colander
 
         # an unlikely usage, but goos to test passing
@@ -4096,11 +4270,11 @@ class TestDeclarativeWithInstantiate(unittest.TestCase, TestFunctional):
         @colander.instantiate(name=name)
         class schema(colander.MappingSchema):
             int = colander.SchemaNode(colander.Int(),
-                                     validator=colander.Range(0, 10))
+                                      validator=colander.Range(0, 10))
             ob = colander.SchemaNode(colander.GlobalObject(package=colander))
+
             @colander.instantiate()
             class seq(colander.SequenceSchema):
-
                 @colander.instantiate()
                 class tup(colander.TupleSchema):
                     tupint = colander.SchemaNode(colander.Int())
@@ -4113,13 +4287,13 @@ class TestDeclarativeWithInstantiate(unittest.TestCase, TestFunctional):
 
             @colander.instantiate()
             class seq2(colander.SequenceSchema):
-
                 @colander.instantiate()
                 class mapping(colander.MappingSchema):
                     key = colander.SchemaNode(colander.Int())
                     key2 = colander.SchemaNode(colander.Int())
 
         return schema
+
 
 class Test_null(unittest.TestCase):
     def test___nonzero__(self):
@@ -4135,6 +4309,7 @@ class Test_null(unittest.TestCase):
         import pickle
         self.assertTrue(pickle.loads(pickle.dumps(null)) is null)
 
+
 class Test_required(unittest.TestCase):
     def test___repr__(self):
         from colander import required
@@ -4144,6 +4319,7 @@ class Test_required(unittest.TestCase):
         from colander import required
         import pickle
         self.assertTrue(pickle.loads(pickle.dumps(required)) is required)
+
 
 class Test_drop(unittest.TestCase):
     def test___repr__(self):
@@ -4158,6 +4334,7 @@ class Test_drop(unittest.TestCase):
 
 class Dummy(object):
     pass
+
 
 class DummySchemaNode(object):
     def __init__(self, typ, name='', exc=None, default=None):
@@ -4185,6 +4362,7 @@ class DummySchemaNode(object):
             if child.name == name:
                 return child
 
+
 class DummyValidator(object):
     def __init__(self, msg=None, children=None):
         self.msg = msg
@@ -4197,11 +4375,13 @@ class DummyValidator(object):
             self.children and e.children.extend(self.children)
             raise e
 
+
 class Uncooperative(object):
     def __str__(self):
         raise ValueError('I wont cooperate')
 
     __unicode__ = __str__
+
 
 class DummyType(object):
     def serialize(self, node, value):
@@ -4215,7 +4395,7 @@ class DummyType(object):
             key = prefix.rstrip('.')
         else:
             key = prefix + 'appstruct'
-        return {key:appstruct}
+        return {key: appstruct}
 
     def unflatten(self, node, paths, fstruct):
         assert paths == [node.name]

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -2339,6 +2339,7 @@ class TestGlobalObject(unittest.TestCase):
                 e.msg.interpolate(),
                 'The dotted name "{0}" cannot be imported'.format(name),
             )
+
     def test_serialize_fail(self):
         typ = self._makeOne()
         node = DummySchemaNode(None)
@@ -2515,6 +2516,7 @@ class TestDateTime(unittest.TestCase):
 
     def test_deserialize_datetime_with_custom_format(self):
         from iso8601 import iso8601
+
         fmt = '%Y%m%d.%H%M%S'
         typ = self._makeOne(format=fmt)
         dt = self._dt()

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -5,6 +5,7 @@ from colander.compat import text_, text_type
 
 def invalid_exc(func, *arg, **kw):
     from colander import Invalid
+
     try:
         func(*arg, **kw)
     except Invalid as e:
@@ -16,6 +17,7 @@ def invalid_exc(func, *arg, **kw):
 class TestInvalid(unittest.TestCase):
     def _makeOne(self, node, msg=None, val=None):
         from colander import Invalid
+
         exc = Invalid(node, msg, val)
         return exc
 
@@ -35,6 +37,7 @@ class TestInvalid(unittest.TestCase):
 
     def test_add_positional(self):
         from colander import Positional
+
         p = Positional()
         node = DummySchemaNode(p)
         exc = self._makeOne(node, 'msg')
@@ -77,6 +80,7 @@ class TestInvalid(unittest.TestCase):
 
     def test_asdict(self):
         from colander import Positional
+
         node1 = DummySchemaNode(None, 'node1')
         node2 = DummySchemaNode(Positional(), 'node2')
         node3 = DummySchemaNode(Positional(), 'node3')
@@ -90,13 +94,16 @@ class TestInvalid(unittest.TestCase):
         exc2.add(exc3, 3)
         exc1.add(exc4, 4)
         d = exc1.asdict()
-        self.assertEqual(d, {'node1.node2.3': 'exc1; exc2; exc3',
-                             'node1.node4': 'exc1; exc4'})
+        self.assertEqual(
+            d,
+            {'node1.node2.3': 'exc1; exc2; exc3', 'node1.node4': 'exc1; exc4'},
+        )
 
     def test_asdict_with_all_validator(self):
         # see https://github.com/Pylons/colander/pull/27
         from colander import All
         from colander import Positional
+
         node1 = DummySchemaNode(None, 'node1')
         node2 = DummySchemaNode(Positional(), 'node2')
         node3 = DummySchemaNode(Positional(), 'node3')
@@ -114,8 +121,11 @@ class TestInvalid(unittest.TestCase):
         d = exc1.asdict()
         self.assertEqual(
             d,
-            {'node1.node2.3': 'exc1; exc2; validator1; validator2',
-             'node1.node3': 'exc1; message1'})
+            {
+                'node1.node2.3': 'exc1; exc2; validator1; validator2',
+                'node1.node3': 'exc1; message1',
+            },
+        )
 
     def test_asdict_with_all_validator_functional(self):
         # see https://github.com/Pylons/colander/issues/2
@@ -140,19 +150,30 @@ class TestInvalid(unittest.TestCase):
             result = e.asdict()
             self.assertEqual(
                 result,
-                {'': ("Number 1 must be lower than number 2; "
-                      "They can't be the same, either")})
+                {
+                    '': (
+                        "Number 1 must be lower than number 2; "
+                        "They can't be the same, either"
+                    )
+                },
+            )
         try:
             schema.deserialize(dict(number1=2, number2=2))
         except c.Invalid as e:
             result = e.asdict(separator=None)
             self.assertEqual(
                 result,
-                {'': ["Number 1 must be lower than number 2",
-                      "They can't be the same, either"]})
+                {
+                    '': [
+                        "Number 1 must be lower than number 2",
+                        "They can't be the same, either",
+                    ]
+                },
+            )
 
     def test___str__(self):
         from colander import Positional
+
         node1 = DummySchemaNode(None, 'node1')
         node2 = DummySchemaNode(Positional(), 'node2')
         node3 = DummySchemaNode(Positional(), 'node3')
@@ -169,7 +190,7 @@ class TestInvalid(unittest.TestCase):
         self.assertEqual(
             result,
             "{'node1.node2.3': 'exc1; exc2; exc3', "
-            "'node1.node4': 'exc1; exc4'}"
+            "'node1.node4': 'exc1; exc4'}",
         )
 
     def test___setitem__fails(self):
@@ -208,6 +229,7 @@ class TestInvalid(unittest.TestCase):
 class TestAll(unittest.TestCase):
     def _makeOne(self, validators):
         from colander import All
+
         return All(*validators)
 
     def test_success(self):
@@ -225,6 +247,7 @@ class TestAll(unittest.TestCase):
 
     def test_Invalid_children(self):
         from colander import Invalid
+
         node1 = DummySchemaNode(None, 'node1')
         node = DummySchemaNode(None, 'node')
         node.children = [node1]
@@ -240,6 +263,7 @@ class TestAll(unittest.TestCase):
 class TestAny(unittest.TestCase):
     def _makeOne(self, validators):
         from colander import Any
+
         return Any(*validators)
 
     def test_success(self):
@@ -257,6 +281,7 @@ class TestAny(unittest.TestCase):
 
     def test_Invalid_children(self):
         from colander import Invalid
+
         node1 = DummySchemaNode(None, 'node1')
         node = DummySchemaNode(None, 'node')
         node.children = [node1]
@@ -270,6 +295,7 @@ class TestAny(unittest.TestCase):
 class TestFunction(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import Function
+
         return Function(*arg, **kw)
 
     def test_success_function_returns_True(self):
@@ -293,6 +319,7 @@ class TestFunction(unittest.TestCase):
 
     def test_deprecated_message(self):
         import warnings
+
         orig_warn = warnings.warn
         log = []
 
@@ -310,6 +337,7 @@ class TestFunction(unittest.TestCase):
 
     def test_deprecated_message_warning(self):
         import warnings
+
         orig_warn = warnings.warn
         log = []
 
@@ -327,8 +355,13 @@ class TestFunction(unittest.TestCase):
             warnings.warn = orig_warn
 
     def test_msg_and_message_error(self):
-        self.assertRaises(ValueError, self._makeOne,
-                          lambda x: False, msg='one', message='two')
+        self.assertRaises(
+            ValueError,
+            self._makeOne,
+            lambda x: False,
+            msg='one',
+            message='two',
+        )
 
     def test_error_message_adds_mapping_to_configured_message(self):
         validator = self._makeOne(lambda x: False, msg='fail ${val}')
@@ -342,6 +375,7 @@ class TestFunction(unittest.TestCase):
 
     def test_error_message_does_not_overwrite_configured_domain(self):
         import translationstring
+
         _ = translationstring.TranslationStringFactory('fnord')
         validator = self._makeOne(lambda x: False, msg=_('fail ${val}'))
         e = invalid_exc(validator, None, None)
@@ -349,6 +383,7 @@ class TestFunction(unittest.TestCase):
 
     def test_error_message_does_not_overwrite_returned_domain(self):
         import translationstring
+
         _ = translationstring.TranslationStringFactory('fnord')
         validator = self._makeOne(lambda x: _('fail ${val}'))
         e = invalid_exc(validator, None, None)
@@ -362,6 +397,7 @@ class TestFunction(unittest.TestCase):
 class TestRange(unittest.TestCase):
     def _makeOne(self, **kw):
         from colander import Range
+
         return Range(**kw)
 
     def test_success_no_bounds(self):
@@ -393,8 +429,9 @@ class TestRange(unittest.TestCase):
     def test_max_failure(self):
         validator = self._makeOne(max=1)
         e = invalid_exc(validator, None, 2)
-        self.assertEqual(e.msg.interpolate(),
-                         '2 is greater than maximum value 1')
+        self.assertEqual(
+            e.msg.interpolate(), '2 is greater than maximum value 1'
+        )
 
     def test_max_failure_msg_override(self):
         validator = self._makeOne(max=1, max_err='wrong')
@@ -405,6 +442,7 @@ class TestRange(unittest.TestCase):
 class TestRegex(unittest.TestCase):
     def _makeOne(self, pattern):
         from colander import Regex
+
         return Regex(pattern)
 
     def test_valid_regex(self):
@@ -415,12 +453,14 @@ class TestRegex(unittest.TestCase):
 
     def test_invalid_regexs(self):
         from colander import Invalid
+
         self.assertRaises(Invalid, self._makeOne('[0-9]+'), None, 'a')
         self.assertRaises(Invalid, self._makeOne('a{2,4}'), None, 'ba')
 
     def test_regex_not_string(self):
         from colander import Invalid
         import re
+
         regex = re.compile('[0-9]+')
         self.assertEqual(self._makeOne(regex)(None, '01'), None)
         self.assertRaises(Invalid, self._makeOne(regex), None, 't')
@@ -429,6 +469,7 @@ class TestRegex(unittest.TestCase):
 class TestEmail(unittest.TestCase):
     def _makeOne(self):
         from colander import Email
+
         return Email()
 
     def test_valid_emails(self):
@@ -448,9 +489,11 @@ class TestEmail(unittest.TestCase):
     def test_invalid_emails(self):
         validator = self._makeOne()
         from colander import Invalid
+
         self.assertRaises(Invalid, validator, None, 'me@here.')
-        self.assertRaises(Invalid,
-                          validator, None, 'name@here.tldiswaytoolooooooooong')
+        self.assertRaises(
+            Invalid, validator, None, 'name@here.tldiswaytoolooooooooong'
+        )
         self.assertRaises(Invalid, validator, None, '@here.us')
         self.assertRaises(Invalid, validator, None, 'me@here..com')
         self.assertRaises(Invalid, validator, None, 'me@we-here-.com')
@@ -460,6 +503,7 @@ class TestEmail(unittest.TestCase):
 class TestLength(unittest.TestCase):
     def _makeOne(self, **kw):
         from colander import Length
+
         return Length(**kw)
 
     def test_success_no_bounds(self):
@@ -502,6 +546,7 @@ class TestLength(unittest.TestCase):
 class TestOneOf(unittest.TestCase):
     def _makeOne(self, values):
         from colander import OneOf
+
         return OneOf(values)
 
     def test_success(self):
@@ -517,6 +562,7 @@ class TestOneOf(unittest.TestCase):
 class TestNoneOf(unittest.TestCase):
     def _makeOne(self, values):
         from colander import NoneOf
+
         return NoneOf(values)
 
     def test_success(self):
@@ -532,6 +578,7 @@ class TestNoneOf(unittest.TestCase):
 class TestContainsOnly(unittest.TestCase):
     def _makeOne(self, values):
         from colander import ContainsOnly
+
         return ContainsOnly(values)
 
     def test_success(self):
@@ -543,12 +590,13 @@ class TestContainsOnly(unittest.TestCase):
         e = invalid_exc(validator, None, [2])
         self.assertEqual(
             e.msg.interpolate(),
-            'One or more of the choices you made was not acceptable'
+            'One or more of the choices you made was not acceptable',
         )
 
     def test_failure_with_custom_error_template(self):
         validator = self._makeOne([1])
         from colander import _
+
         validator.err_template = _('${val}: ${choices}')
         e = invalid_exc(validator, None, [2])
         self.assertTrue('[2]' in e.msg.interpolate())
@@ -557,20 +605,24 @@ class TestContainsOnly(unittest.TestCase):
 class Test_luhnok(unittest.TestCase):
     def _callFUT(self, node, value):
         from colander import luhnok
+
         return luhnok(node, value)
 
     def test_fail(self):
         import colander
+
         val = '10'
         self.assertRaises(colander.Invalid, self._callFUT, None, val)
 
     def test_fail2(self):
         import colander
+
         val = '99999999999999999999999'
         self.assertRaises(colander.Invalid, self._callFUT, None, val)
 
     def test_fail3(self):
         import colander
+
         val = 'abcdefghij'
         self.assertRaises(colander.Invalid, self._callFUT, None, val)
 
@@ -582,6 +634,7 @@ class Test_luhnok(unittest.TestCase):
 class Test_url_validator(unittest.TestCase):
     def _callFUT(self, val):
         from colander import url
+
         return url(None, val)
 
     def test_it_success(self):
@@ -592,12 +645,14 @@ class Test_url_validator(unittest.TestCase):
     def test_it_failure(self):
         val = 'not-a-url'
         from colander import Invalid
+
         self.assertRaises(Invalid, self._callFUT, val)
 
 
 class TestUUID(unittest.TestCase):
     def _callFUT(self, val):
         from colander import uuid
+
         return uuid(None, val)
 
     def test_success_hexadecimal(self):
@@ -628,28 +683,33 @@ class TestUUID(unittest.TestCase):
     def test_failure_random_string(self):
         val = 'not-a-uuid'
         from colander import Invalid
+
         self.assertRaises(Invalid, self._callFUT, val)
 
     def test_failure_not_hexadecimal(self):
         val = '123zzzzz-uuuu-zzzz-uuuu-42665544zzzz'
         from colander import Invalid
+
         self.assertRaises(Invalid, self._callFUT, val)
 
     def test_failure_invalid_length(self):
         # Correct UUID: 8-4-4-4-12
         val = '88888888-333-4444-333-cccccccccccc'
         from colander import Invalid
+
         self.assertRaises(Invalid, self._callFUT, val)
 
     def test_failure_with_invalid_urn_ns(self):
         val = 'urn:abcd:{123e4567-e89b-12d3-a456-426655440000}'
         from colander import Invalid
+
         self.assertRaises(Invalid, self._callFUT, val)
 
 
 class TestSchemaType(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import SchemaType
+
         return SchemaType(*arg, **kw)
 
     def test_flatten(self):
@@ -673,12 +733,12 @@ class TestSchemaType(unittest.TestCase):
     def test_set_value(self):
         typ = self._makeOne()
         self.assertRaises(
-            AssertionError, typ.set_value, None, None, None, None)
+            AssertionError, typ.set_value, None, None, None, None
+        )
 
     def test_get_value(self):
         typ = self._makeOne()
-        self.assertRaises(
-            AssertionError, typ.get_value, None, None, None)
+        self.assertRaises(AssertionError, typ.get_value, None, None, None)
 
     def test_cstruct_children(self):
         typ = self._makeOne()
@@ -688,6 +748,7 @@ class TestSchemaType(unittest.TestCase):
 class TestMapping(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import Mapping
+
         return Mapping(*arg, **kw)
 
     def test_ctor_bad_unknown(self):
@@ -708,25 +769,30 @@ class TestMapping(unittest.TestCase):
         # None
         e = invalid_exc(typ.deserialize, node, None)
         self.assertTrue(
-            e.msg.interpolate().startswith('"None" is not a mapping type'))
+            e.msg.interpolate().startswith('"None" is not a mapping type')
+        )
 
         # list
         e = invalid_exc(typ.deserialize, node, [])
         self.assertTrue(
-            e.msg.interpolate().startswith('"[]" is not a mapping type'))
+            e.msg.interpolate().startswith('"[]" is not a mapping type')
+        )
 
         # str
         e = invalid_exc(typ.deserialize, node, "")
         self.assertTrue(
-            e.msg.interpolate().startswith('"" is not a mapping type'))
+            e.msg.interpolate().startswith('"" is not a mapping type')
+        )
 
         # tuple
         e = invalid_exc(typ.deserialize, node, ())
         self.assertTrue(
-            e.msg.interpolate().startswith('"()" is not a mapping type'))
+            e.msg.interpolate().startswith('"()" is not a mapping type')
+        )
 
     def test_deserialize_null(self):
         import colander
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.deserialize(node, colander.null)
@@ -747,14 +813,16 @@ class TestMapping(unittest.TestCase):
 
     def test_deserialize_unknown_raise(self):
         import colander
+
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne(unknown='raise')
         e = invalid_exc(typ.deserialize, node, {'a': 1, 'b': 2})
         self.assertTrue(isinstance(e, colander.UnsupportedFields))
         self.assertEqual(e.fields, {'b': 2})
-        self.assertEqual(e.msg.interpolate(),
-                         "Unrecognized keys in mapping: \"{'b': 2}\"")
+        self.assertEqual(
+            e.msg.interpolate(), "Unrecognized keys in mapping: \"{'b': 2}\""
+        )
 
     def test_deserialize_unknown_preserve(self):
         node = DummySchemaNode(None)
@@ -776,6 +844,7 @@ class TestMapping(unittest.TestCase):
 
     def test_deserialize_subnode_missing_default(self):
         import colander
+
         node = DummySchemaNode(None)
         node.children = [
             DummySchemaNode(None, name='a'),
@@ -787,6 +856,7 @@ class TestMapping(unittest.TestCase):
 
     def test_serialize_null(self):
         import colander
+
         val = colander.null
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -798,7 +868,8 @@ class TestMapping(unittest.TestCase):
         typ = self._makeOne()
         e = invalid_exc(typ.serialize, node, None)
         self.assertTrue(
-            e.msg.interpolate().startswith('"None" is not a mapping type'))
+            e.msg.interpolate().startswith('"None" is not a mapping type')
+        )
 
     def test_serialize_no_subnodes(self):
         node = DummySchemaNode(None)
@@ -815,9 +886,7 @@ class TestMapping(unittest.TestCase):
 
     def test_serialize_with_unknown(self):
         node = DummySchemaNode(None)
-        node.children = [
-            DummySchemaNode(None, name='a'),
-        ]
+        node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
         result = typ.serialize(node, {'a': 1, 'b': 2})
         self.assertEqual(result, {'a': 1})
@@ -825,6 +894,7 @@ class TestMapping(unittest.TestCase):
     def test_serialize_value_is_null(self):
         node = DummySchemaNode(None)
         from colander import null
+
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
         result = typ.serialize(node, null)
@@ -832,6 +902,7 @@ class TestMapping(unittest.TestCase):
 
     def test_serialize_value_has_drop(self):
         from colander import drop
+
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
@@ -874,7 +945,7 @@ class TestMapping(unittest.TestCase):
         result = typ.unflatten(
             node,
             ['node', 'node.a', 'node.b'],
-            {'node': {'a': 1, 'b': 2}, 'node.a': 1, 'node.b': 2}
+            {'node': {'a': 1, 'b': 2}, 'node.a': 1, 'node.b': 2},
         )
         self.assertEqual(result, {'a': 1, 'b': 2})
 
@@ -894,9 +965,15 @@ class TestMapping(unittest.TestCase):
         node.children = [one, two]
         typ = self._makeOne()
         result = typ.unflatten(
-            node, [
-                'node', 'node.one', 'node.one.a', 'node.one.b',
-                'node.two', 'node.two.c', 'node.two.d'
+            node,
+            [
+                'node',
+                'node.one',
+                'node.one.a',
+                'node.one.b',
+                'node.two',
+                'node.two.c',
+                'node.two.d',
             ],
             {
                 'node': {'one': {'a': 1, 'b': 2}, 'two': {'c': 3, 'd': 4}},
@@ -906,10 +983,11 @@ class TestMapping(unittest.TestCase):
                 'node.one.b': 2,
                 'node.two.c': 3,
                 'node.two.d': 4,
-            }
+            },
         )
-        self.assertEqual(result, {
-            'one': {'a': 1, 'b': 2}, 'two': {'c': 3, 'd': 4}})
+        self.assertEqual(
+            result, {'one': {'a': 1, 'b': 2}, 'two': {'c': 3, 'd': 4}}
+        )
 
     def test_set_value(self):
         typ = self._makeOne()
@@ -926,12 +1004,15 @@ class TestMapping(unittest.TestCase):
         node2 = DummySchemaNode(typ, name='node2')
         node1.children = [node2]
         appstruct = {'node2': {'foo': 'bar', 'baz': 'baz'}}
-        self.assertEqual(typ.get_value(node1, appstruct, 'node2'),
-                         {'foo': 'bar', 'baz': 'baz'})
+        self.assertEqual(
+            typ.get_value(node1, appstruct, 'node2'),
+            {'foo': 'bar', 'baz': 'baz'},
+        )
         self.assertEqual(typ.get_value(node1, appstruct, 'node2.foo'), 'bar')
 
     def test_cstruct_children_cstruct_is_null(self):
         from colander import null
+
         typ = self._makeOne()
         node1 = DummySchemaNode(typ, name='node1')
         node2 = DummySchemaNode(typ, name='node2')
@@ -941,6 +1022,7 @@ class TestMapping(unittest.TestCase):
 
     def test_cstruct_children(self):
         from colander import null
+
         typ = self._makeOne()
         node1 = DummySchemaNode(typ, name='node1')
         node2 = DummySchemaNode(typ, name='node2')
@@ -953,15 +1035,14 @@ class TestMapping(unittest.TestCase):
 class TestTuple(unittest.TestCase):
     def _makeOne(self):
         from colander import Tuple
+
         return Tuple()
 
     def test_deserialize_not_iterable(self):
         node = DummySchemaNode(None)
         typ = self._makeOne()
         e = invalid_exc(typ.deserialize, node, None)
-        self.assertEqual(
-            e.msg.interpolate(),
-            '"None" is not iterable')
+        self.assertEqual(e.msg.interpolate(), '"None" is not iterable')
         self.assertEqual(e.node, node)
 
     def test_deserialize_no_subnodes(self):
@@ -972,6 +1053,7 @@ class TestTuple(unittest.TestCase):
 
     def test_deserialize_null(self):
         import colander
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.deserialize(node, colander.null)
@@ -992,7 +1074,7 @@ class TestTuple(unittest.TestCase):
         self.assertEqual(
             e.msg.interpolate(),
             "\"('a', 'b')\" has an incorrect number of "
-            "elements (expected 1, was 2)"
+            "elements (expected 1, was 2)",
         )
 
     def test_deserialize_toosmall(self):
@@ -1002,7 +1084,7 @@ class TestTuple(unittest.TestCase):
         e = invalid_exc(typ.deserialize, node, ())
         self.assertEqual(
             e.msg.interpolate(),
-            '"()" has an incorrect number of elements (expected 1, was 0)'
+            '"()" has an incorrect number of elements (expected 1, was 0)',
         )
 
     def test_deserialize_subnodes_raise(self):
@@ -1018,6 +1100,7 @@ class TestTuple(unittest.TestCase):
 
     def test_serialize_null(self):
         import colander
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.serialize(node, colander.null)
@@ -1027,9 +1110,7 @@ class TestTuple(unittest.TestCase):
         node = DummySchemaNode(None)
         typ = self._makeOne()
         e = invalid_exc(typ.serialize, node, None)
-        self.assertEqual(
-            e.msg.interpolate(),
-            '"None" is not iterable')
+        self.assertEqual(e.msg.interpolate(), '"None" is not iterable')
         self.assertEqual(e.node, node)
 
     def test_serialize_no_subnodes(self):
@@ -1053,7 +1134,7 @@ class TestTuple(unittest.TestCase):
         self.assertEqual(
             e.msg.interpolate(),
             "\"('a', 'b')\" has an incorrect number of "
-            "elements (expected 1, was 2)"
+            "elements (expected 1, was 2)",
         )
 
     def test_serialize_toosmall(self):
@@ -1063,7 +1144,7 @@ class TestTuple(unittest.TestCase):
         e = invalid_exc(typ.serialize, node, ())
         self.assertEqual(
             e.msg.interpolate(),
-            '"()" has an incorrect number of elements (expected 1, was 0)'
+            '"()" has an incorrect number of elements (expected 1, was 0)',
         )
 
     def test_serialize_subnodes_raise(self):
@@ -1110,8 +1191,11 @@ class TestTuple(unittest.TestCase):
             DummySchemaNode(int2, name='b'),
         ]
         typ = self._makeOne()
-        result = typ.unflatten(node, ['node', 'node.a', 'node.b'],
-                               {'node': (1, 2), 'node.a': 1, 'node.b': 2})
+        result = typ.unflatten(
+            node,
+            ['node', 'node.a', 'node.b'],
+            {'node': (1, 2), 'node.a': 1, 'node.b': 2},
+        )
         self.assertEqual(result, (1, 2))
 
     def test_set_value(self):
@@ -1119,7 +1203,7 @@ class TestTuple(unittest.TestCase):
         node = DummySchemaNode(typ, name='node')
         node.children = [
             DummySchemaNode(typ, name='foo'),
-            DummySchemaNode(typ, name='bar')
+            DummySchemaNode(typ, name='bar'),
         ]
         node['foo'].children = [
             DummySchemaNode(None, name='a'),
@@ -1138,17 +1222,16 @@ class TestTuple(unittest.TestCase):
         node = DummySchemaNode(typ, name='node')
         node.children = [
             DummySchemaNode(None, name='foo'),
-            DummySchemaNode(None, name='bar')
+            DummySchemaNode(None, name='bar'),
         ]
-        self.assertRaises(
-            KeyError, typ.set_value, node, (1, 2), 'foobar', 34)
+        self.assertRaises(KeyError, typ.set_value, node, (1, 2), 'foobar', 34)
 
     def test_get_value(self):
         typ = self._makeOne()
         node = DummySchemaNode(typ, name='node')
         node.children = [
             DummySchemaNode(typ, name='foo'),
-            DummySchemaNode(typ, name='bar')
+            DummySchemaNode(typ, name='bar'),
         ]
         node['foo'].children = [
             DummySchemaNode(None, name='a'),
@@ -1167,13 +1250,13 @@ class TestTuple(unittest.TestCase):
         node = DummySchemaNode(typ, name='node')
         node.children = [
             DummySchemaNode(None, name='foo'),
-            DummySchemaNode(None, name='bar')
+            DummySchemaNode(None, name='bar'),
         ]
-        self.assertRaises(
-            KeyError, typ.get_value, node, (1, 2), 'foobar')
+        self.assertRaises(KeyError, typ.get_value, node, (1, 2), 'foobar')
 
     def test_cstruct_children_cstruct_is_null(self):
         from colander import null
+
         typ = self._makeOne()
         node1 = DummySchemaNode(typ, name='node1')
         node2 = DummySchemaNode(typ, name='node2')
@@ -1192,6 +1275,7 @@ class TestTuple(unittest.TestCase):
 
     def test_cstruct_children_toofew(self):
         from colander import null
+
         typ = self._makeOne()
         node1 = DummySchemaNode(typ, name='node1')
         node2 = DummySchemaNode(typ, name='node2')
@@ -1213,6 +1297,7 @@ class TestTuple(unittest.TestCase):
 class TestSet(unittest.TestCase):
     def _makeOne(self, **kw):
         from colander import Set
+
         return Set(**kw)
 
     def test_serialize(self):
@@ -1224,6 +1309,7 @@ class TestSet(unittest.TestCase):
 
     def test_serialize_null(self):
         from colander import null
+
         typ = self._makeOne()
         node = DummySchemaNode(typ)
         result = typ.serialize(node, null)
@@ -1243,6 +1329,7 @@ class TestSet(unittest.TestCase):
 
     def test_deserialize_null(self):
         from colander import null
+
         typ = self._makeOne()
         node = DummySchemaNode(typ)
         result = typ.deserialize(node, null)
@@ -1264,6 +1351,7 @@ class TestSet(unittest.TestCase):
 class TestList(unittest.TestCase):
     def _makeOne(self, **kw):
         from colander import List
+
         return List(**kw)
 
     def test_serialize(self):
@@ -1275,6 +1363,7 @@ class TestList(unittest.TestCase):
 
     def test_serialize_null(self):
         from colander import null
+
         typ = self._makeOne()
         node = DummySchemaNode(typ)
         result = typ.serialize(node, null)
@@ -1294,6 +1383,7 @@ class TestList(unittest.TestCase):
 
     def test_deserialize_null(self):
         from colander import null
+
         typ = self._makeOne()
         node = DummySchemaNode(typ)
         result = typ.deserialize(node, null)
@@ -1315,11 +1405,13 @@ class TestList(unittest.TestCase):
 class TestSequence(unittest.TestCase):
     def _makeOne(self, **kw):
         from colander import Sequence
+
         return Sequence(**kw)
 
     def test_alias(self):
         from colander import Seq
         from colander import Sequence
+
         self.assertEqual(Seq, Sequence)
 
     def test_deserialize_not_iterable(self):
@@ -1327,9 +1419,7 @@ class TestSequence(unittest.TestCase):
         typ = self._makeOne()
         node.children = [node]
         e = invalid_exc(typ.deserialize, node, None)
-        self.assertEqual(
-            e.msg.interpolate(),
-            '"None" is not iterable')
+        self.assertEqual(e.msg.interpolate(), '"None" is not iterable')
         self.assertEqual(e.node, node)
 
     def test_deserialize_not_iterable_accept_scalar(self):
@@ -1355,6 +1445,7 @@ class TestSequence(unittest.TestCase):
 
     def test_deserialize_no_null(self):
         import colander
+
         typ = self._makeOne()
         result = typ.deserialize(None, colander.null)
         self.assertEqual(result, colander.null)
@@ -1377,6 +1468,7 @@ class TestSequence(unittest.TestCase):
 
     def test_serialize_null(self):
         import colander
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.serialize(node, colander.null)
@@ -1384,6 +1476,7 @@ class TestSequence(unittest.TestCase):
 
     def test_serialize_drop(self):
         from colander import drop
+
         node = DummySchemaNode(None)
         node.children = [DummySchemaNode(None, name='a')]
         typ = self._makeOne()
@@ -1395,9 +1488,7 @@ class TestSequence(unittest.TestCase):
         typ = self._makeOne()
         node.children = [node]
         e = invalid_exc(typ.serialize, node, None)
-        self.assertEqual(
-            e.msg.interpolate(),
-            '"None" is not iterable')
+        self.assertEqual(e.msg.interpolate(), '"None" is not iterable')
         self.assertEqual(e.node, node)
 
     def test_serialize_not_iterable_accept_scalar(self):
@@ -1438,41 +1529,34 @@ class TestSequence(unittest.TestCase):
 
     def test_flatten(self):
         node = DummySchemaNode(None, name='node')
-        node.children = [
-            DummySchemaNode(DummyType(), name='foo'),
-        ]
+        node.children = [DummySchemaNode(DummyType(), name='foo')]
         typ = self._makeOne()
         result = typ.flatten(node, [1, 2])
         self.assertEqual(result, {'node.0': 1, 'node.1': 2})
 
     def test_flatten_with_integer(self):
         from colander import Integer
+
         node = DummySchemaNode(None, name='node')
-        node.children = [
-            DummySchemaNode(Integer(), name='foo'),
-        ]
+        node.children = [DummySchemaNode(Integer(), name='foo')]
         typ = self._makeOne()
         result = typ.flatten(node, [1, 2])
         self.assertEqual(result, {'node.0': 1, 'node.1': 2})
 
     def test_flatten_listitem(self):
         node = DummySchemaNode(None, name='node')
-        node.children = [
-            DummySchemaNode(DummyType(), name='foo'),
-        ]
+        node.children = [DummySchemaNode(DummyType(), name='foo')]
         typ = self._makeOne()
         result = typ.flatten(node, [1, 2], listitem=True)
         self.assertEqual(result, {'0': 1, '1': 2})
 
     def test_unflatten(self):
         node = DummySchemaNode(None, name='node')
-        node.children = [
-            DummySchemaNode(DummyType(), name='foo'),
-        ]
+        node.children = [DummySchemaNode(DummyType(), name='foo')]
         typ = self._makeOne()
-        result = typ.unflatten(node,
-                               ['node.0', 'node.1', ],
-                               {'node.0': 'a', 'node.1': 'b'})
+        result = typ.unflatten(
+            node, ['node.0', 'node.1'], {'node.0': 'a', 'node.1': 'b'}
+        )
         self.assertEqual(result, ['a', 'b'])
 
     def test_setvalue(self):
@@ -1498,12 +1582,14 @@ class TestSequence(unittest.TestCase):
     def test_cstruct_children_cstruct_is_null(self):
         from colander import null
         from colander import SequenceItems
+
         typ = self._makeOne()
         result = typ.cstruct_children(None, null)
         self.assertEqual(result, SequenceItems([]))
 
     def test_cstruct_children_cstruct_is_non_null(self):
         from colander import SequenceItems
+
         typ = self._makeOne()
         result = typ.cstruct_children(None, ['a'])
         self.assertEqual(result, SequenceItems(['a']))
@@ -1512,15 +1598,18 @@ class TestSequence(unittest.TestCase):
 class TestString(unittest.TestCase):
     def _makeOne(self, encoding=None, allow_empty=False):
         from colander import String
+
         return String(encoding, allow_empty)
 
     def test_alias(self):
         from colander import Str
         from colander import String
+
         self.assertEqual(Str, String)
 
     def test_deserialize_emptystring(self):
         from colander import null
+
         node = DummySchemaNode(None)
         typ = self._makeOne(None)
         result = typ.deserialize(node, '')
@@ -1545,6 +1634,7 @@ class TestString(unittest.TestCase):
 
     def test_deserialize_nonunicode_from_None(self):
         import colander
+
         value = object()
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1568,6 +1658,7 @@ class TestString(unittest.TestCase):
 
     def test_deserialize_from_nonstring_obj(self):
         import colander
+
         value = object()
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1575,6 +1666,7 @@ class TestString(unittest.TestCase):
 
     def test_serialize_null(self):
         from colander import null
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.serialize(node, null)
@@ -1642,15 +1734,18 @@ class TestString(unittest.TestCase):
 class TestInteger(unittest.TestCase):
     def _makeOne(self):
         from colander import Integer
+
         return Integer()
 
     def test_alias(self):
         from colander import Int
         from colander import Integer
+
         self.assertEqual(Int, Integer)
 
     def test_serialize_null(self):
         import colander
+
         val = colander.null
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1659,6 +1754,7 @@ class TestInteger(unittest.TestCase):
 
     def test_deserialize_emptystring(self):
         import colander
+
         val = ''
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1704,10 +1800,12 @@ class TestInteger(unittest.TestCase):
 class TestFloat(unittest.TestCase):
     def _makeOne(self):
         from colander import Float
+
         return Float()
 
     def test_serialize_null(self):
         import colander
+
         val = colander.null
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1716,6 +1814,7 @@ class TestFloat(unittest.TestCase):
 
     def test_serialize_emptystring(self):
         import colander
+
         val = ''
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1754,10 +1853,12 @@ class TestFloat(unittest.TestCase):
 class TestDecimal(unittest.TestCase):
     def _makeOne(self, quant=None, rounding=None, normalize=False):
         from colander import Decimal
+
         return Decimal(quant, rounding, normalize)
 
     def test_serialize_null(self):
         import colander
+
         val = colander.null
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1766,6 +1867,7 @@ class TestDecimal(unittest.TestCase):
 
     def test_serialize_emptystring(self):
         import colander
+
         val = ''
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1780,6 +1882,7 @@ class TestDecimal(unittest.TestCase):
 
     def test_serialize_quantize_with_rounding_up(self):
         import decimal
+
         val = '.000001'
         node = DummySchemaNode(None)
         typ = self._makeOne('.01', decimal.ROUND_UP)
@@ -1788,6 +1891,7 @@ class TestDecimal(unittest.TestCase):
 
     def test_serialize_normalize(self):
         from decimal import Decimal
+
         val = Decimal('1.00')
         node = DummySchemaNode(None)
         typ = self._makeOne(normalize=True)
@@ -1803,6 +1907,7 @@ class TestDecimal(unittest.TestCase):
 
     def test_deserialize_ok(self):
         import decimal
+
         val = '1.0'
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1811,6 +1916,7 @@ class TestDecimal(unittest.TestCase):
 
     def test_deserialize_with_quantize(self):
         import decimal
+
         val = '1.00000001'
         node = DummySchemaNode(None)
         typ = self._makeOne('.01', decimal.ROUND_UP)
@@ -1819,6 +1925,7 @@ class TestDecimal(unittest.TestCase):
 
     def test_deserialize_with_normalize(self):
         from decimal import Decimal
+
         val = '1.00'
         node = DummySchemaNode(None)
         typ = self._makeOne(normalize=True)
@@ -1844,6 +1951,7 @@ class TestDecimal(unittest.TestCase):
 class TestMoney(unittest.TestCase):
     def _makeOne(self):
         from colander import Money
+
         return Money()
 
     def test_serialize_rounds_up(self):
@@ -1855,6 +1963,7 @@ class TestMoney(unittest.TestCase):
 
     def test_deserialize_rounds_up(self):
         import decimal
+
         val = '1.00000001'
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1865,15 +1974,18 @@ class TestMoney(unittest.TestCase):
 class TestBoolean(unittest.TestCase):
     def _makeOne(self):
         from colander import Boolean
+
         return Boolean()
 
     def test_alias(self):
         from colander import Bool
         from colander import Boolean
+
         self.assertEqual(Bool, Boolean)
 
     def test_serialize_null(self):
         import colander
+
         val = colander.null
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -1897,6 +2009,7 @@ class TestBoolean(unittest.TestCase):
 
     def test_deserialize_null(self):
         import colander
+
         typ = self._makeOne()
         node = DummySchemaNode(None)
         result = typ.deserialize(node, colander.null)
@@ -1914,6 +2027,7 @@ class TestBoolean(unittest.TestCase):
 class TestBooleanCustomFalseReprs(unittest.TestCase):
     def _makeOne(self):
         from colander import Boolean
+
         return Boolean(false_choices=('n', 'f'))
 
     def test_deserialize(self):
@@ -1927,10 +2041,12 @@ class TestBooleanCustomFalseReprs(unittest.TestCase):
 class TestBooleanCustomFalseAndTrueReprs(unittest.TestCase):
     def _makeOne(self):
         from colander import Boolean
+
         return Boolean(false_choices=('n', 'f'), true_choices=('y', 't'))
 
     def test_deserialize(self):
         import colander
+
         typ = self._makeOne()
         node = DummySchemaNode(None)
         self.assertEqual(typ.deserialize(node, 'f'), False)
@@ -1948,6 +2064,7 @@ class TestBooleanCustomFalseAndTrueReprs(unittest.TestCase):
 class TestBooleanCustomSerializations(unittest.TestCase):
     def _makeOne(self):
         from colander import Boolean
+
         return Boolean(false_val='no', true_val='yes')
 
     def test_serialize(self):
@@ -1962,41 +2079,48 @@ class TestBooleanCustomSerializations(unittest.TestCase):
 class TestGlobalObject(unittest.TestCase):
     def _makeOne(self, package=None):
         from colander import GlobalObject
+
         return GlobalObject(package)
 
     def test_zope_dottedname_style_resolve_absolute(self):
         typ = self._makeOne()
         result = typ._zope_dottedname_style(
-            None,
-            'colander.tests.test_colander.TestGlobalObject'
+            None, 'colander.tests.test_colander.TestGlobalObject'
         )
         self.assertEqual(result, self.__class__)
 
     def test_zope_dottedname_style_irrresolveable_absolute(self):
         typ = self._makeOne()
-        self.assertRaises(ImportError, typ._zope_dottedname_style, None,
-                          'colander.tests.nonexisting')
+        self.assertRaises(
+            ImportError,
+            typ._zope_dottedname_style,
+            None,
+            'colander.tests.nonexisting',
+        )
 
     def test__zope_dottedname_style_resolve_relative(self):
         import colander
+
         typ = self._makeOne(package=colander)
         node = DummySchemaNode(None)
         result = typ._zope_dottedname_style(
-            node,
-            '.tests.test_colander.TestGlobalObject')
+            node, '.tests.test_colander.TestGlobalObject'
+        )
         self.assertEqual(result, self.__class__)
 
     def test__zope_dottedname_style_resolve_relative_leading_dots(self):
         import colander
+
         typ = self._makeOne(package=colander.tests)
         node = DummySchemaNode(None)
         result = typ._zope_dottedname_style(
-            node,
-            '..tests.test_colander.TestGlobalObject')
+            node, '..tests.test_colander.TestGlobalObject'
+        )
         self.assertEqual(result, self.__class__)
 
     def test__zope_dottedname_style_resolve_relative_is_dot(self):
         import colander.tests
+
         typ = self._makeOne(package=colander.tests)
         result = typ._zope_dottedname_style(None, '.')
         self.assertEqual(result, colander.tests)
@@ -2006,70 +2130,82 @@ class TestGlobalObject(unittest.TestCase):
         e = invalid_exc(typ._zope_dottedname_style, None, '.')
         self.assertEqual(
             e.msg.interpolate(),
-            'relative name "." irresolveable without package')
+            'relative name "." irresolveable without package',
+        )
 
     def test_zope_dottedname_style_resolve_relative_nocurrentpackage(self):
         typ = self._makeOne()
         e = invalid_exc(typ._zope_dottedname_style, None, '.whatever')
         self.assertEqual(
             e.msg.interpolate(),
-            'relative name ".whatever" irresolveable without package')
+            'relative name ".whatever" irresolveable without package',
+        )
 
     def test_zope_dottedname_style_irrresolveable_relative(self):
         import colander.tests
+
         typ = self._makeOne(package=colander)
-        self.assertRaises(ImportError, typ._zope_dottedname_style, None,
-                          '.notexisting')
+        self.assertRaises(
+            ImportError, typ._zope_dottedname_style, None, '.notexisting'
+        )
 
     def test__zope_dottedname_style_resolveable_relative(self):
         import colander
+
         typ = self._makeOne(package=colander)
         result = typ._zope_dottedname_style(None, '.tests')
         from colander import tests
+
         self.assertEqual(result, tests)
 
     def test__zope_dottedname_style_irresolveable_absolute(self):
         typ = self._makeOne()
         self.assertRaises(
-            ImportError,
-            typ._zope_dottedname_style, None, 'colander.fudge.bar')
+            ImportError, typ._zope_dottedname_style, None, 'colander.fudge.bar'
+        )
 
     def test__zope_dottedname_style_resolveable_absolute(self):
         typ = self._makeOne()
         result = typ._zope_dottedname_style(
-            None,
-            'colander.tests.test_colander.TestGlobalObject')
+            None, 'colander.tests.test_colander.TestGlobalObject'
+        )
         self.assertEqual(result, self.__class__)
 
     def test__pkg_resources_style_resolve_absolute(self):
         typ = self._makeOne()
         result = typ._pkg_resources_style(
-            None,
-            'colander.tests.test_colander:TestGlobalObject'
+            None, 'colander.tests.test_colander:TestGlobalObject'
         )
         self.assertEqual(result, self.__class__)
 
     def test__pkg_resources_style_irrresolveable_absolute(self):
         typ = self._makeOne()
-        self.assertRaises(ImportError, typ._pkg_resources_style, None,
-                          'colander.tests.test_colander:nonexisting')
+        self.assertRaises(
+            ImportError,
+            typ._pkg_resources_style,
+            None,
+            'colander.tests.test_colander:nonexisting',
+        )
 
     def test__pkg_resources_style_resolve_relative_startswith_colon(self):
         import colander.tests
+
         typ = self._makeOne(package=colander.tests)
         result = typ._pkg_resources_style(None, ':fixture')
         self.assertEqual(result, 1)
 
     def test__pkg_resources_style_resolve_relative_startswith_dot(self):
         import colander
+
         typ = self._makeOne(package=colander)
         result = typ._pkg_resources_style(
-            None,
-            '.tests.test_colander:TestGlobalObject')
+            None, '.tests.test_colander:TestGlobalObject'
+        )
         self.assertEqual(result, self.__class__)
 
     def test__pkg_resources_style_resolve_relative_is_dot(self):
         import colander.tests
+
         typ = self._makeOne(package=colander.tests)
         result = typ._pkg_resources_style(None, '.')
         self.assertEqual(result, colander.tests)
@@ -2077,17 +2213,22 @@ class TestGlobalObject(unittest.TestCase):
     def test__pkg_resources_style_resolve_relative_nocurrentpackage(self):
         typ = self._makeOne()
         import colander
-        self.assertRaises(colander.Invalid, typ._pkg_resources_style, None,
-                          '.whatever')
+
+        self.assertRaises(
+            colander.Invalid, typ._pkg_resources_style, None, '.whatever'
+        )
 
     def test__pkg_resources_style_irrresolveable_relative(self):
         import colander.tests
+
         typ = self._makeOne(package=colander)
-        self.assertRaises(ImportError, typ._pkg_resources_style, None,
-                          ':notexisting')
+        self.assertRaises(
+            ImportError, typ._pkg_resources_style, None, ':notexisting'
+        )
 
     def test_deserialize_None(self):
         import colander
+
         typ = self._makeOne()
         node = DummySchemaNode(None)
         result = typ.deserialize(node, None)
@@ -2095,6 +2236,7 @@ class TestGlobalObject(unittest.TestCase):
 
     def test_deserialize_null(self):
         import colander
+
         typ = self._makeOne()
         node = DummySchemaNode(None)
         result = typ.deserialize(node, colander.null)
@@ -2102,6 +2244,7 @@ class TestGlobalObject(unittest.TestCase):
 
     def test_deserialize_notastring(self):
         import colander
+
         typ = self._makeOne()
         node = DummySchemaNode(None)
         self.assertRaises(colander.Invalid, typ.deserialize, node, True)
@@ -2110,27 +2253,30 @@ class TestGlobalObject(unittest.TestCase):
         typ = self._makeOne()
         node = DummySchemaNode(None)
         result = typ.deserialize(
-            node,
-            'colander.tests.test_colander:TestGlobalObject')
+            node, 'colander.tests.test_colander:TestGlobalObject'
+        )
         self.assertEqual(result, self.__class__)
 
     def test_deserialize_using_zope_dottedname_style(self):
         typ = self._makeOne()
         node = DummySchemaNode(None)
         result = typ.deserialize(
-            node,
-            'colander.tests.test_colander.TestGlobalObject')
+            node, 'colander.tests.test_colander.TestGlobalObject'
+        )
         self.assertEqual(result, self.__class__)
 
     def test_deserialize_style_raises(self):
         typ = self._makeOne()
         node = DummySchemaNode(None)
         e = invalid_exc(typ.deserialize, node, 'cant.be.found')
-        self.assertEqual(e.msg.interpolate(),
-                         'The dotted name "cant.be.found" cannot be imported')
+        self.assertEqual(
+            e.msg.interpolate(),
+            'The dotted name "cant.be.found" cannot be imported',
+        )
 
     def test_serialize_null(self):
         import colander
+
         val = colander.null
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -2139,12 +2285,14 @@ class TestGlobalObject(unittest.TestCase):
 
     def test_serialize_ok(self):
         import colander.tests
+
         typ = self._makeOne()
         node = DummySchemaNode(None)
         result = typ.serialize(node, colander.tests)
         self.assertEqual(result, 'colander.tests')
 
         from colander import tests
+
         typ = self._makeOne()
         node = DummySchemaNode(None)
         result = typ.serialize(node, tests)
@@ -2161,6 +2309,7 @@ class TestGlobalObject(unittest.TestCase):
 
     def test_deserialize_class_ok(self):
         import colander
+
         names = (
             'colander.tests.test_colander.TestGlobalObject',
             '.tests.test_colander.TestGlobalObject',
@@ -2180,15 +2329,15 @@ class TestGlobalObject(unittest.TestCase):
 
     def test_deserialize_class_fail(self):
         import colander
-        names = ('.test_colander.TestGlobalObject',
-                 '.TestGlobalObject')
+
+        names = ('.test_colander.TestGlobalObject', '.TestGlobalObject')
         typ = self._makeOne(colander)
         node = DummySchemaNode(None)
         for name in names:
             e = invalid_exc(typ.deserialize, node, name)
             self.assertEqual(
                 e.msg.interpolate(),
-                'The dotted name "{0}" cannot be imported'.format(name)
+                'The dotted name "{0}" cannot be imported'.format(name),
             )
 
     def test_serialize_fail(self):
@@ -2201,18 +2350,22 @@ class TestGlobalObject(unittest.TestCase):
 class TestDateTime(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import DateTime
+
         return DateTime(*arg, **kw)
 
     def _dt(self):
         import datetime
+
         return datetime.datetime(2010, 4, 26, 10, 48)
 
     def _today(self):
         import datetime
+
         return datetime.date.today()
 
     def test_ctor_default_tzinfo_not_specified(self):
         from iso8601 import iso8601
+
         typ = self._makeOne()
         self.assertIs(typ.default_tzinfo, iso8601.UTC)
 
@@ -2222,12 +2375,14 @@ class TestDateTime(unittest.TestCase):
 
     def test_ctor_default_tzinfo_non_None(self):
         from iso8601 import iso8601
+
         tzinfo = iso8601.FixedOffset(1, 0, 'myname')
         typ = self._makeOne(default_tzinfo=tzinfo)
         self.assertEqual(typ.default_tzinfo, tzinfo)
 
     def test_serialize_null(self):
         import colander
+
         val = colander.null
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -2236,6 +2391,7 @@ class TestDateTime(unittest.TestCase):
 
     def test_serialize_none(self):
         import colander
+
         val = None
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -2246,11 +2402,13 @@ class TestDateTime(unittest.TestCase):
         typ = self._makeOne()
         node = DummySchemaNode(None)
         e = invalid_exc(typ.serialize, node, 'garbage')
-        self.assertEqual(e.msg.interpolate(),
-                         '"garbage" is not a datetime object')
+        self.assertEqual(
+            e.msg.interpolate(), '"garbage" is not a datetime object'
+        )
 
     def test_serialize_with_date(self):
         import datetime
+
         typ = self._makeOne()
         date = self._today()
         node = DummySchemaNode(None)
@@ -2276,6 +2434,7 @@ class TestDateTime(unittest.TestCase):
 
     def test_serialize_with_tzware_datetime(self):
         from iso8601 import iso8601
+
         typ = self._makeOne()
         dt = self._dt()
         tzinfo = iso8601.FixedOffset(1, 0, 'myname')
@@ -2288,6 +2447,7 @@ class TestDateTime(unittest.TestCase):
     def test_deserialize_date(self):
         import datetime
         from iso8601 import iso8601
+
         date = self._today()
         typ = self._makeOne()
         formatted = date.isoformat()
@@ -2311,6 +2471,7 @@ class TestDateTime(unittest.TestCase):
 
     def test_deserialize_null(self):
         import colander
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.deserialize(node, colander.null)
@@ -2318,6 +2479,7 @@ class TestDateTime(unittest.TestCase):
 
     def test_deserialize_empty(self):
         import colander
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.deserialize(node, '')
@@ -2325,6 +2487,7 @@ class TestDateTime(unittest.TestCase):
 
     def test_deserialize_success(self):
         from iso8601 import iso8601
+
         typ = self._makeOne()
         dt = self._dt()
         tzinfo = iso8601.FixedOffset(1, 0, 'myname')
@@ -2336,6 +2499,7 @@ class TestDateTime(unittest.TestCase):
 
     def test_deserialize_naive_with_default_tzinfo(self):
         from iso8601 import iso8601
+
         tzinfo = iso8601.FixedOffset(1, 0, 'myname')
         typ = self._makeOne(default_tzinfo=tzinfo)
         dt = self._dt()
@@ -2358,18 +2522,22 @@ class TestDateTime(unittest.TestCase):
 class TestDate(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import Date
+
         return Date(*arg, **kw)
 
     def _dt(self):
         import datetime
+
         return datetime.datetime(2010, 4, 26, 10, 48)
 
     def _today(self):
         import datetime
+
         return datetime.date.today()
 
     def test_serialize_null(self):
         import colander
+
         val = colander.null
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -2378,6 +2546,7 @@ class TestDate(unittest.TestCase):
 
     def test_serialize_none(self):
         import colander
+
         val = None
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -2420,6 +2589,7 @@ class TestDate(unittest.TestCase):
 
     def test_deserialize_null(self):
         import colander
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.deserialize(node, colander.null)
@@ -2427,6 +2597,7 @@ class TestDate(unittest.TestCase):
 
     def test_deserialize_empty(self):
         import colander
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.deserialize(node, '')
@@ -2452,18 +2623,22 @@ class TestDate(unittest.TestCase):
 class TestTime(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import Time
+
         return Time(*arg, **kw)
 
     def _dt(self):
         import datetime
+
         return datetime.datetime(2010, 4, 26, 10, 48)
 
     def _now(self):
         import datetime
+
         return datetime.datetime.now().time()
 
     def test_serialize_null(self):
         import colander
+
         val = colander.null
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -2472,6 +2647,7 @@ class TestTime(unittest.TestCase):
 
     def test_serialize_none(self):
         import colander
+
         val = None
         node = DummySchemaNode(None)
         typ = self._makeOne()
@@ -2494,6 +2670,7 @@ class TestTime(unittest.TestCase):
 
     def test_serialize_with_zero_time(self):
         import datetime
+
         typ = self._makeOne()
         time = datetime.time(0)
         node = DummySchemaNode(None)
@@ -2517,6 +2694,7 @@ class TestTime(unittest.TestCase):
 
     def test_deserialize_three_digit_string(self):
         import datetime
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.deserialize(node, '11:00:11')
@@ -2524,6 +2702,7 @@ class TestTime(unittest.TestCase):
 
     def test_deserialize_two_digit_string(self):
         import datetime
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.deserialize(node, '11:00')
@@ -2531,6 +2710,7 @@ class TestTime(unittest.TestCase):
 
     def test_deserialize_null(self):
         import colander
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.deserialize(node, colander.null)
@@ -2538,6 +2718,7 @@ class TestTime(unittest.TestCase):
 
     def test_deserialize_empty(self):
         import colander
+
         node = DummySchemaNode(None)
         typ = self._makeOne()
         result = typ.deserialize(node, '')
@@ -2545,6 +2726,7 @@ class TestTime(unittest.TestCase):
 
     def test_deserialize_missing_seconds(self):
         import datetime
+
         typ = self._makeOne()
         node = DummySchemaNode(None)
         result = typ.deserialize(node, '10:12')
@@ -2552,6 +2734,7 @@ class TestTime(unittest.TestCase):
 
     def test_deserialize_success_time(self):
         import datetime
+
         typ = self._makeOne()
         node = DummySchemaNode(None)
         result = typ.deserialize(node, '10:12:13')
@@ -2563,8 +2746,9 @@ class TestTime(unittest.TestCase):
         iso = dt.isoformat()
         node = DummySchemaNode(None)
         result = typ.deserialize(node, iso)
-        self.assertEqual(result.isoformat(),
-                         dt.time().isoformat().split('.')[0])
+        self.assertEqual(
+            result.isoformat(), dt.time().isoformat().split('.')[0]
+        )
 
 
 class TestEnum(unittest.TestCase):
@@ -2612,8 +2796,13 @@ class TestEnum(unittest.TestCase):
             one = 1
             other = 1
 
-        self.assertRaises(ValueError, colander.Enum, NonUniqueEnum,
-                          attr='value', typ=colander.Integer())
+        self.assertRaises(
+            ValueError,
+            colander.Enum,
+            NonUniqueEnum,
+            attr='value',
+            typ=colander.Integer(),
+        )
 
     def test_non_unique_failure2(self):
         import colander
@@ -2627,11 +2816,17 @@ class TestEnum(unittest.TestCase):
                 self.val0 = val0
                 self.val1 = val1
 
-        self.assertRaises(ValueError, colander.Enum, NonUniqueEnum,
-                          attr='val0', typ=colander.Integer())
+        self.assertRaises(
+            ValueError,
+            colander.Enum,
+            NonUniqueEnum,
+            attr='val0',
+            typ=colander.Integer(),
+        )
 
     def test_serialize_null(self):
         import colander
+
         e, typ = self._makeOne()
         val = colander.null
         node = DummySchemaNode(None)
@@ -2667,6 +2862,7 @@ class TestEnum(unittest.TestCase):
 
     def test_deserialize_null(self):
         import colander
+
         e, typ = self._makeOne()
         val = ''
         node = DummySchemaNode(None)
@@ -2710,6 +2906,7 @@ class TestEnum(unittest.TestCase):
 class TestSchemaNode(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from colander import SchemaNode
+
         return SchemaNode(*arg, **kw)
 
     def test_new_sets_order(self):
@@ -2719,8 +2916,13 @@ class TestSchemaNode(unittest.TestCase):
     def test_ctor_no_title(self):
         child = DummySchemaNode(None, name='fred')
         node = self._makeOne(
-            None, child, validator=1, default=2,
-            name='name_a', missing='missing')
+            None,
+            child,
+            validator=1,
+            default=2,
+            name='name_a',
+            missing='missing',
+        )
         self.assertEqual(node.typ, None)
         self.assertEqual(node.children, [child])
         self.assertEqual(node.validator, 1)
@@ -2731,8 +2933,9 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_ctor_with_title(self):
         child = DummySchemaNode(None, name='fred')
-        node = self._makeOne(None, child, validator=1, default=2, name='name',
-                             title='title')
+        node = self._makeOne(
+            None, child, validator=1, default=2, name='name', title='title'
+        )
         self.assertEqual(node.typ, None)
         self.assertEqual(node.children, [child])
         self.assertEqual(node.validator, 1)
@@ -2741,8 +2944,14 @@ class TestSchemaNode(unittest.TestCase):
         self.assertEqual(node.title, 'title')
 
     def test_ctor_with_description(self):
-        node = self._makeOne(None, validator=1, default=2, name='name',
-                             title='title', description='desc')
+        node = self._makeOne(
+            None,
+            validator=1,
+            default=2,
+            name='name',
+            title='title',
+            description='desc',
+        )
         self.assertEqual(node.description, 'desc')
 
     def test_ctor_with_widget(self):
@@ -2784,6 +2993,7 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_required_deferred(self):
         from colander import deferred
+
         node = self._makeOne(None, missing=deferred(lambda: '123'))
         self.assertEqual(node.required, True)
 
@@ -2795,6 +3005,7 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_deserialize_with_preparer(self):
         from colander import Invalid
+
         typ = DummyType()
 
         def preparer(value):
@@ -2804,14 +3015,12 @@ class TestSchemaNode(unittest.TestCase):
             if not value.startswith('prepared'):
                 raise Invalid(node, 'not prepared')  # pragma: no cover
 
-        node = self._makeOne(typ,
-                             preparer=preparer,
-                             validator=validator)
-        self.assertEqual(node.deserialize('value'),
-                         'prepared_value')
+        node = self._makeOne(typ, preparer=preparer, validator=validator)
+        self.assertEqual(node.deserialize('value'), 'prepared_value')
 
     def test_deserialize_with_multiple_preparers(self):
         from colander import Invalid
+
         typ = DummyType()
 
         def preparer1(value):
@@ -2824,14 +3033,16 @@ class TestSchemaNode(unittest.TestCase):
             if not value.startswith('prepared2_prepared1'):
                 raise Invalid(node, 'not prepared')  # pragma: no cover
 
-        node = self._makeOne(typ,
-                             preparer=[preparer1, preparer2],
-                             validator=validator)
-        self.assertEqual(node.deserialize('value'),
-                         'prepared2_prepared1_value')
+        node = self._makeOne(
+            typ, preparer=[preparer1, preparer2], validator=validator
+        )
+        self.assertEqual(
+            node.deserialize('value'), 'prepared2_prepared1_value'
+        )
 
     def test_deserialize_preparer_before_missing_check(self):
         from colander import null
+
         typ = DummyType()
 
         def preparer(value):
@@ -2852,6 +3063,7 @@ class TestSchemaNode(unittest.TestCase):
         from colander import Invalid
         from colander import deferred
         from colander import UnboundDeferredError
+
         typ = DummyType()
 
         def validator(node, kw):
@@ -2867,12 +3079,14 @@ class TestSchemaNode(unittest.TestCase):
     def test_deserialize_value_is_null_no_missing(self):
         from colander import null
         from colander import Invalid
+
         typ = DummyType()
         node = self._makeOne(typ)
         self.assertRaises(Invalid, node.deserialize, null)
 
     def test_deserialize_value_is_null_with_missing(self):
         from colander import null
+
         typ = DummyType()
         node = self._makeOne(typ)
         node.missing = 'abc'
@@ -2880,6 +3094,7 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_deserialize_value_is_null_with_missing_msg(self):
         from colander import null
+
         typ = DummyType()
         node = self._makeOne(typ, missing_msg='Missing')
         e = invalid_exc(node.deserialize, null)
@@ -2887,9 +3102,11 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_deserialize_value_with_interpolated_missing_msg(self):
         from colander import null
+
         typ = DummyType()
-        node = self._makeOne(typ, missing_msg='Missing attribute ${title}',
-                             name='name_a')
+        node = self._makeOne(
+            typ, missing_msg='Missing attribute ${title}', name='name_a'
+        )
         e = invalid_exc(node.deserialize, null)
         self.assertEqual(e.msg.interpolate(), 'Missing attribute Name A')
 
@@ -2901,6 +3118,7 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_deserialize_null_can_be_used_as_missing(self):
         from colander import null
+
         typ = DummyType()
         node = self._makeOne(typ)
         node.missing = null
@@ -2910,6 +3128,7 @@ class TestSchemaNode(unittest.TestCase):
         from colander import null
         from colander import deferred
         from colander import Invalid
+
         typ = DummyType()
         node = self._makeOne(typ)
         node.missing = deferred(lambda: '123')
@@ -2923,6 +3142,7 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_serialize_value_is_null_no_default(self):
         from colander import null
+
         typ = DummyType()
         node = self._makeOne(typ)
         result = node.serialize(null)
@@ -2930,6 +3150,7 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_serialize_value_is_null_with_default(self):
         from colander import null
+
         typ = DummyType()
         node = self._makeOne(typ)
         node.default = 1
@@ -2945,6 +3166,7 @@ class TestSchemaNode(unittest.TestCase):
     def test_serialize_default_deferred(self):
         from colander import deferred
         from colander import null
+
         typ = DummyType()
         node = self._makeOne(typ)
         node.default = deferred(lambda: 'abc')
@@ -3051,8 +3273,9 @@ class TestSchemaNode(unittest.TestCase):
             for child, child_clone in zip(schema.children, cloned.children):
                 self.assertIsNot(child, child_clone)
                 for name in child.__dict__.keys():
-                    self.assertEqual(getattr(child, name),
-                                     getattr(child_clone, name))
+                    self.assertEqual(
+                        getattr(child, name), getattr(child_clone, name)
+                    )
 
         # add a child node before cloning
         schema = Schema()
@@ -3073,19 +3296,14 @@ class TestSchemaNode(unittest.TestCase):
         class Schema(colander.MappingSchema):
             n1 = colander.SchemaNode(colander.Mapping(unknown='preserve'))
 
-        foo = {
-            "n1": {
-                "bar": {
-                    "baz": "qux",
-                },
-            },
-        }
+        foo = {"n1": {"bar": {"baz": "qux"}}}
         bar = Schema().serialize(foo)
         bar["n1"]["bar"]["baz"] = "foobar"
         self.assertEqual(foo["n1"]["bar"]["baz"], "qux")
 
     def test_bind(self):
         from colander import deferred
+
         inner_typ = DummyType()
         outer_typ = DummyType()
 
@@ -3096,8 +3314,9 @@ class TestSchemaNode(unittest.TestCase):
 
         dv = deferred(dv)
         outer_node = self._makeOne(outer_typ, name='outer', missing=dv)
-        inner_node = self._makeOne(inner_typ, name='inner', validator=dv,
-                                   missing=dv)
+        inner_node = self._makeOne(
+            inner_typ, name='inner', validator=dv, missing=dv
+        )
         outer_node.children = [inner_node]
         outer_clone = outer_node.bind(a=1)
         self.assertFalse(outer_clone is outer_node)
@@ -3109,6 +3328,7 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_bind_with_after_bind(self):
         from colander import deferred
+
         inner_typ = DummyType()
         outer_typ = DummyType()
 
@@ -3123,10 +3343,12 @@ class TestSchemaNode(unittest.TestCase):
             self.assertEqual(kw, {'a': 1})
             del node['inner']
 
-        outer_node = self._makeOne(outer_typ, name='outer', missing=dv,
-                                   after_bind=remove_inner)
-        inner_node = self._makeOne(inner_typ, name='inner', validator=dv,
-                                   missing=dv)
+        outer_node = self._makeOne(
+            outer_typ, name='outer', missing=dv, after_bind=remove_inner
+        )
+        inner_node = self._makeOne(
+            inner_typ, name='inner', validator=dv, missing=dv
+        )
         outer_node.children = [inner_node]
         outer_clone = outer_node.bind(a=1)
         self.assertFalse(outer_clone is outer_node)
@@ -3142,7 +3364,7 @@ class TestSchemaNode(unittest.TestCase):
             fnord = colander.SchemaNode(
                 colander.Sequence(),
                 colander.SchemaNode(colander.Integer(), name=''),
-                name="fnord[]"
+                name="fnord[]",
             )
 
         schema = FnordSchema()
@@ -3156,6 +3378,7 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_cstruct_children_warning(self):
         import warnings
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             typ = None
@@ -3165,6 +3388,7 @@ class TestSchemaNode(unittest.TestCase):
 
     def test_raise_invalid(self):
         import colander
+
         typ = DummyType()
         node = self._makeOne(typ)
         self.assertRaises(colander.Invalid, node.raise_invalid, 'Wrong')
@@ -3329,9 +3553,7 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
 
         class MyNode(colander.SchemaNode):
             schema_type = colander.Mapping
-            title = colander.SchemaNode(
-                colander.String(),
-            )
+            title = colander.SchemaNode(colander.String())
 
         node = MyNode()
         self.assertEqual(node.title, '')
@@ -3339,10 +3561,7 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
     def test_schema_child_names_conflict_with_value_names_used(self):
         import colander
 
-        doesntmatter = colander.SchemaNode(
-            colander.String(),
-            name='name',
-        )
+        doesntmatter = colander.SchemaNode(colander.String(), name='name')
 
         class MyNode(colander.SchemaNode):
             schema_type = colander.Mapping
@@ -3356,13 +3575,8 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
     def test_schema_child_names_conflict_with_value_names_in_superclass(self):
         import colander
 
-        doesntmatter = colander.SchemaNode(
-            colander.String(),
-            name='name',
-        )
-        _name = colander.SchemaNode(
-            colander.String(),
-        )
+        doesntmatter = colander.SchemaNode(colander.String(), name='name')
+        _name = colander.SchemaNode(colander.String())
 
         class MyNode(colander.SchemaNode):
             schema_type = colander.Mapping
@@ -3380,18 +3594,13 @@ class TestSchemaNodeSubclassing(unittest.TestCase):
         import colander
 
         class MyNode(colander.SchemaNode):
-            name = colander.SchemaNode(
-                colander.String(),
-                id='name',
-            )
+            name = colander.SchemaNode(colander.String(), id='name')
 
         class AnotherNode(MyNode):
             schema_type = colander.Mapping
             name = 'fred'
             doesntmatter = colander.SchemaNode(
-                colander.String(),
-                name='name',
-                id='doesntmatter',
+                colander.String(), name='name', id='doesntmatter'
             )
 
         node = AnotherNode()
@@ -3404,146 +3613,73 @@ class TestMappingSchemaInheritance(unittest.TestCase):
         import colander
 
         class Friend(colander.Schema):
-            rank = colander.SchemaNode(
-                colander.Int(),
-                id='rank',
-            )
-            name = colander.SchemaNode(
-                colander.String(),
-                id='name'
-            )
-            serial = colander.SchemaNode(
-                colander.Bool(),
-                id='serial2',
-            )
+            rank = colander.SchemaNode(colander.Int(), id='rank')
+            name = colander.SchemaNode(colander.String(), id='name')
+            serial = colander.SchemaNode(colander.Bool(), id='serial2')
 
         class SpecialFriend(Friend):
             iwannacomefirst = colander.SchemaNode(
-                colander.Int(),
-                id='iwannacomefirst2',
+                colander.Int(), id='iwannacomefirst2'
             )
 
         class SuperSpecialFriend(SpecialFriend):
             iwannacomefirst = colander.SchemaNode(
-                colander.String(),
-                id='iwannacomefirst1',
+                colander.String(), id='iwannacomefirst1'
             )
-            another = colander.SchemaNode(
-                colander.String(),
-                id='another',
-            )
-            serial = colander.SchemaNode(
-                colander.Int(),
-                id='serial1',
-            )
+            another = colander.SchemaNode(colander.String(), id='another')
+            serial = colander.SchemaNode(colander.Int(), id='serial1')
 
         inst = SuperSpecialFriend()
         self.assertEqual(
             [x.id for x in inst.children],
-            [
-                'rank',
-                'name',
-                'serial1',
-                'iwannacomefirst1',
-                'another',
-            ]
+            ['rank', 'name', 'serial1', 'iwannacomefirst1', 'another'],
         )
 
     def test_single_inheritance_with_insert_before(self):
         import colander
 
         class Friend(colander.Schema):
-            rank = colander.SchemaNode(
-                colander.Int(),
-                id='rank',
-            )
-            name = colander.SchemaNode(
-                colander.String(),
-                id='name'
-            )
+            rank = colander.SchemaNode(colander.Int(), id='rank')
+            name = colander.SchemaNode(colander.String(), id='name')
             serial = colander.SchemaNode(
-                colander.Bool(),
-                insert_before='name',
-                id='serial2',
+                colander.Bool(), insert_before='name', id='serial2'
             )
 
         class SpecialFriend(Friend):
             iwannacomefirst = colander.SchemaNode(
-                colander.Int(),
-                id='iwannacomefirst2',
+                colander.Int(), id='iwannacomefirst2'
             )
 
         class SuperSpecialFriend(SpecialFriend):
             iwannacomefirst = colander.SchemaNode(
-                colander.String(),
-                insert_before='rank',
-                id='iwannacomefirst1',
+                colander.String(), insert_before='rank', id='iwannacomefirst1'
             )
-            another = colander.SchemaNode(
-                colander.String(),
-                id='another',
-            )
-            serial = colander.SchemaNode(
-                colander.Int(),
-                id='serial1',
-            )
+            another = colander.SchemaNode(colander.String(), id='another')
+            serial = colander.SchemaNode(colander.Int(), id='serial1')
 
         inst = SuperSpecialFriend()
         self.assertEqual(
             [x.id for x in inst.children],
-            [
-                'iwannacomefirst1',
-                'rank',
-                'serial1',
-                'name',
-                'another',
-            ]
+            ['iwannacomefirst1', 'rank', 'serial1', 'name', 'another'],
         )
 
     def test_single_inheritance2(self):
         import colander
 
         class One(colander.Schema):
-            a = colander.SchemaNode(
-                colander.Int(),
-                id='a1',
-            )
-            b = colander.SchemaNode(
-                colander.Int(),
-                id='b1',
-            )
-            d = colander.SchemaNode(
-                colander.Int(),
-                id='d1',
-            )
+            a = colander.SchemaNode(colander.Int(), id='a1')
+            b = colander.SchemaNode(colander.Int(), id='b1')
+            d = colander.SchemaNode(colander.Int(), id='d1')
 
         class Two(One):
-            a = colander.SchemaNode(
-                colander.String(),
-                id='a2',
-            )
-            c = colander.SchemaNode(
-                colander.String(),
-                id='c2',
-            )
-            e = colander.SchemaNode(
-                colander.String(),
-                id='e2',
-            )
+            a = colander.SchemaNode(colander.String(), id='a2')
+            c = colander.SchemaNode(colander.String(), id='c2')
+            e = colander.SchemaNode(colander.String(), id='e2')
 
         class Three(Two):
-            b = colander.SchemaNode(
-                colander.Bool(),
-                id='b3',
-            )
-            d = colander.SchemaNode(
-                colander.Bool(),
-                id='d3',
-            )
-            f = colander.SchemaNode(
-                colander.Bool(),
-                id='f3',
-            )
+            b = colander.SchemaNode(colander.Bool(), id='b3')
+            d = colander.SchemaNode(colander.Bool(), id='d3')
+            f = colander.SchemaNode(colander.Bool(), id='f3')
 
         inst = Three()
         c = inst.children
@@ -3555,46 +3691,19 @@ class TestMappingSchemaInheritance(unittest.TestCase):
         import colander
 
         class One(colander.Schema):
-            a = colander.SchemaNode(
-                colander.Int(),
-                id='a1',
-            )
-            b = colander.SchemaNode(
-                colander.Int(),
-                id='b1',
-            )
-            d = colander.SchemaNode(
-                colander.Int(),
-                id='d1',
-            )
+            a = colander.SchemaNode(colander.Int(), id='a1')
+            b = colander.SchemaNode(colander.Int(), id='b1')
+            d = colander.SchemaNode(colander.Int(), id='d1')
 
         class Two(colander.Schema):
-            a = colander.SchemaNode(
-                colander.String(),
-                id='a2',
-            )
-            c = colander.SchemaNode(
-                colander.String(),
-                id='c2',
-            )
-            e = colander.SchemaNode(
-                colander.String(),
-                id='e2',
-            )
+            a = colander.SchemaNode(colander.String(), id='a2')
+            c = colander.SchemaNode(colander.String(), id='c2')
+            e = colander.SchemaNode(colander.String(), id='e2')
 
         class Three(Two, One):
-            b = colander.SchemaNode(
-                colander.Bool(),
-                id='b3',
-            )
-            d = colander.SchemaNode(
-                colander.Bool(),
-                id='d3',
-            )
-            f = colander.SchemaNode(
-                colander.Bool(),
-                id='f3',
-            )
+            b = colander.SchemaNode(colander.Bool(), id='b3')
+            d = colander.SchemaNode(colander.Bool(), id='d3')
+            f = colander.SchemaNode(colander.Bool(), id='f3')
 
         inst = Three()
         c = inst.children
@@ -3606,13 +3715,8 @@ class TestMappingSchemaInheritance(unittest.TestCase):
         import colander
 
         class One(colander.Schema):
-            a = colander.SchemaNode(
-                colander.Int(),
-            )
-            b = colander.SchemaNode(
-                colander.Int(),
-                insert_before='c'
-            )
+            a = colander.SchemaNode(colander.Int())
+            b = colander.SchemaNode(colander.Int(), insert_before='c')
 
         self.assertRaises(KeyError, One)
 
@@ -3620,6 +3724,7 @@ class TestMappingSchemaInheritance(unittest.TestCase):
 class TestDeferred(unittest.TestCase):
     def _makeOne(self, wrapped):
         from colander import deferred
+
         return deferred(wrapped)
 
     def test_ctor(self):
@@ -3677,6 +3782,7 @@ class TestSchema(unittest.TestCase):
     def test_alias(self):
         from colander import Schema
         from colander import MappingSchema
+
         self.assertEqual(Schema, MappingSchema)
 
     def test_it(self):
@@ -3736,6 +3842,7 @@ class TestSchema(unittest.TestCase):
 
     def test_imperative_with_implicit_schema_type(self):
         import colander
+
         node = colander.SchemaNode(colander.String())
         schema = colander.Schema(node)
         self.assertEqual(schema.schema_type, colander.Mapping)
@@ -3743,6 +3850,7 @@ class TestSchema(unittest.TestCase):
 
     def test_schema_with_cloned_nodes(self):
         import colander
+
         test_node = colander.SchemaNode(colander.String())
 
         class TestSchema(colander.Schema):
@@ -3758,6 +3866,7 @@ class TestSchema(unittest.TestCase):
 class TestSequenceSchema(unittest.TestCase):
     def test_succeed(self):
         import colander
+
         _inner = colander.SchemaNode(colander.String())
 
         class MySchema(colander.SequenceSchema):
@@ -3771,6 +3880,7 @@ class TestSequenceSchema(unittest.TestCase):
 
     def test_fail_toomany(self):
         import colander
+
         thingnode = colander.SchemaNode(colander.String())
         thingnode2 = colander.SchemaNode(colander.String())
 
@@ -3780,8 +3890,8 @@ class TestSequenceSchema(unittest.TestCase):
 
         e = invalid_exc(MySchema)
         self.assertEqual(
-            e.msg,
-            'Sequence schemas must have exactly one child node')
+            e.msg, 'Sequence schemas must have exactly one child node'
+        )
 
     def test_fail_toofew(self):
         import colander
@@ -3791,11 +3901,12 @@ class TestSequenceSchema(unittest.TestCase):
 
         e = invalid_exc(MySchema)
         self.assertEqual(
-            e.msg,
-            'Sequence schemas must have exactly one child node')
+            e.msg, 'Sequence schemas must have exactly one child node'
+        )
 
     def test_imperative_with_implicit_schema_type(self):
         import colander
+
         node = colander.SchemaNode(colander.String())
         schema = colander.SequenceSchema(node)
         self.assertEqual(schema.schema_type, colander.Sequence)
@@ -3825,6 +3936,7 @@ class TestSequenceSchema(unittest.TestCase):
 
     def test_clone_with_sequence_schema(self):
         import colander
+
         thingnode = colander.SchemaNode(colander.String(), name='foo')
         schema = colander.SequenceSchema(colander.Sequence(), thingnode)
         clone = schema.clone()
@@ -3850,6 +3962,7 @@ class TestTupleSchema(unittest.TestCase):
 
     def test_imperative_with_implicit_schema_type(self):
         import colander
+
         node = colander.SchemaNode(colander.String())
         schema = colander.TupleSchema(node)
         self.assertEqual(schema.schema_type, colander.Tuple)
@@ -3859,6 +3972,7 @@ class TestTupleSchema(unittest.TestCase):
 class TestFunctional(object):
     def test_deserialize_ok(self):
         import colander.tests
+
         data = {
             'int': '10',
             'ob': 'colander.tests',
@@ -3870,14 +3984,17 @@ class TestFunctional(object):
         result = schema.deserialize(data)
         self.assertEqual(result['int'], 10)
         self.assertEqual(result['ob'], colander.tests)
-        self.assertEqual(result['seq'],
-                         [(1, 's'), (2, 's'), (3, 's'), (4, 's')])
-        self.assertEqual(result['seq2'],
-                         [{'key': 1, 'key2': 2}, {'key': 3, 'key2': 4}])
+        self.assertEqual(
+            result['seq'], [(1, 's'), (2, 's'), (3, 's'), (4, 's')]
+        )
+        self.assertEqual(
+            result['seq2'], [{'key': 1, 'key2': 2}, {'key': 3, 'key2': 4}]
+        )
         self.assertEqual(result['tup'], (1, 's'))
 
     def test_flatten_ok(self):
         import colander
+
         appstruct = {
             'int': 10,
             'ob': colander.tests,
@@ -3914,6 +4031,7 @@ class TestFunctional(object):
 
     def test_flatten_mapping_has_no_name(self):
         import colander
+
         appstruct = {
             'int': 10,
             'ob': colander.tests,
@@ -3950,6 +4068,7 @@ class TestFunctional(object):
 
     def test_unflatten_ok(self):
         import colander
+
         fstruct = {
             'schema.seq.2.tupstring': 's',
             'schema.seq2.0.key2': 2,
@@ -3986,6 +4105,7 @@ class TestFunctional(object):
 
     def test_unflatten_mapping_no_name(self):
         import colander
+
         fstruct = {
             'seq.2.tupstring': 's',
             'seq2.0.key2': 2,
@@ -4022,6 +4142,7 @@ class TestFunctional(object):
 
     def test_flatten_unflatten_roundtrip(self):
         import colander
+
         appstruct = {
             'int': 10,
             'ob': colander.tests,
@@ -4031,11 +4152,12 @@ class TestFunctional(object):
         }
         schema = self._makeSchema(name='')
         self.assertEqual(
-            schema.unflatten(schema.flatten(appstruct)),
-            appstruct)
+            schema.unflatten(schema.flatten(appstruct)), appstruct
+        )
 
     def test_set_value(self):
         import colander
+
         appstruct = {
             'int': 10,
             'ob': colander.tests,
@@ -4049,6 +4171,7 @@ class TestFunctional(object):
 
     def test_get_value(self):
         import colander
+
         appstruct = {
             'int': 10,
             'ob': colander.tests,
@@ -4057,15 +4180,17 @@ class TestFunctional(object):
             'tup': (1, 's'),
         }
         schema = self._makeSchema()
-        self.assertEqual(schema.get_value(appstruct, 'seq'),
-                         [(1, 's'), (2, 's'), (3, 's'), (4, 's')])
+        self.assertEqual(
+            schema.get_value(appstruct, 'seq'),
+            [(1, 's'), (2, 's'), (3, 's'), (4, 's')],
+        )
         self.assertEqual(schema.get_value(appstruct, 'seq2.1.key'), 3)
 
     def test_invalid_asdict(self):
         expected = {
             'schema.int': '20 is greater than maximum value 10',
             'schema.ob': 'The dotted name "no.way.this.exists" '
-                         'cannot be imported',
+            'cannot be imported',
             'schema.seq.0.0': '"q" is not a number',
             'schema.seq.1.0': '"w" is not a number',
             'schema.seq.2.0': '"e" is not a number',
@@ -4074,7 +4199,8 @@ class TestFunctional(object):
             'schema.seq2.0.key2': '"y" is not a number',
             'schema.seq2.1.key': '"u" is not a number',
             'schema.seq2.1.key2': '"i" is not a number',
-            'schema.tup.0': '"s" is not a number'}
+            'schema.tup.0': '"s" is not a number',
+        }
         data = {
             'int': '20',
             'ob': 'no.way.this.exists',
@@ -4121,71 +4247,45 @@ class TestFunctional(object):
 
 
 class TestImperative(unittest.TestCase, TestFunctional):
-
     def _makeSchema(self, name='schema'):
         import colander
 
         integer = colander.SchemaNode(
-            colander.Integer(),
-            name='int',
-            validator=colander.Range(0, 10)
+            colander.Integer(), name='int', validator=colander.Range(0, 10)
         )
 
         ob = colander.SchemaNode(
-            colander.GlobalObject(package=colander),
-            name='ob',
+            colander.GlobalObject(package=colander), name='ob'
         )
 
         tup = colander.SchemaNode(
             colander.Tuple(),
-            colander.SchemaNode(
-                colander.Integer(),
-                name='tupint',
-            ),
-            colander.SchemaNode(
-                colander.String(),
-                name='tupstring',
-            ),
+            colander.SchemaNode(colander.Integer(), name='tupint'),
+            colander.SchemaNode(colander.String(), name='tupstring'),
             name='tup',
         )
 
-        seq = colander.SchemaNode(
-            colander.Sequence(),
-            tup,
-            name='seq',
-        )
+        seq = colander.SchemaNode(colander.Sequence(), tup, name='seq')
 
         seq2 = colander.SchemaNode(
             colander.Sequence(),
             colander.SchemaNode(
                 colander.Mapping(),
-                colander.SchemaNode(
-                    colander.Integer(),
-                    name='key',
-                ),
-                colander.SchemaNode(
-                    colander.Integer(),
-                    name='key2',
-                ),
+                colander.SchemaNode(colander.Integer(), name='key'),
+                colander.SchemaNode(colander.Integer(), name='key2'),
                 name='mapping',
             ),
             name='seq2',
         )
 
         schema = colander.SchemaNode(
-            colander.Mapping(),
-            integer,
-            ob,
-            tup,
-            seq,
-            seq2,
-            name=name)
+            colander.Mapping(), integer, ob, tup, seq, seq2, name=name
+        )
 
         return schema
 
 
 class TestDeclarative(unittest.TestCase, TestFunctional):
-
     def _makeSchema(self, name='schema'):
         import colander
 
@@ -4204,8 +4304,9 @@ class TestDeclarative(unittest.TestCase, TestFunctional):
             mapping = MappingSchema()
 
         class MainSchema(colander.MappingSchema):
-            int = colander.SchemaNode(colander.Int(),
-                                      validator=colander.Range(0, 10))
+            int = colander.SchemaNode(
+                colander.Int(), validator=colander.Range(0, 10)
+            )
             ob = colander.SchemaNode(colander.GlobalObject(package=colander))
             seq = SequenceOne()
             tup = TupleSchema()
@@ -4216,7 +4317,6 @@ class TestDeclarative(unittest.TestCase, TestFunctional):
 
 
 class TestUltraDeclarative(unittest.TestCase, TestFunctional):
-
     def _makeSchema(self, name='schema'):
         import colander
 
@@ -4261,7 +4361,6 @@ class TestUltraDeclarative(unittest.TestCase, TestFunctional):
 
 
 class TestDeclarativeWithInstantiate(unittest.TestCase, TestFunctional):
-
     def _makeSchema(self, name='schema'):
         import colander
 
@@ -4269,8 +4368,9 @@ class TestDeclarativeWithInstantiate(unittest.TestCase, TestFunctional):
         # parameters to instantiation works
         @colander.instantiate(name=name)
         class schema(colander.MappingSchema):
-            int = colander.SchemaNode(colander.Int(),
-                                      validator=colander.Range(0, 10))
+            int = colander.SchemaNode(
+                colander.Int(), validator=colander.Range(0, 10)
+            )
             ob = colander.SchemaNode(colander.GlobalObject(package=colander))
 
             @colander.instantiate()
@@ -4298,37 +4398,44 @@ class TestDeclarativeWithInstantiate(unittest.TestCase, TestFunctional):
 class Test_null(unittest.TestCase):
     def test___nonzero__(self):
         from colander import null
+
         self.assertFalse(null)
 
     def test___repr__(self):
         from colander import null
+
         self.assertEqual(repr(null), '<colander.null>')
 
     def test_pickling(self):
         from colander import null
         import pickle
+
         self.assertTrue(pickle.loads(pickle.dumps(null)) is null)
 
 
 class Test_required(unittest.TestCase):
     def test___repr__(self):
         from colander import required
+
         self.assertEqual(repr(required), '<colander.required>')
 
     def test_pickling(self):
         from colander import required
         import pickle
+
         self.assertTrue(pickle.loads(pickle.dumps(required)) is required)
 
 
 class Test_drop(unittest.TestCase):
     def test___repr__(self):
         from colander import drop
+
         self.assertEqual(repr(drop), '<colander.drop>')
 
     def test_pickling(self):
         from colander import drop
         import pickle
+
         self.assertTrue(pickle.loads(pickle.dumps(drop)) is drop)
 
 
@@ -4347,12 +4454,14 @@ class DummySchemaNode(object):
 
     def deserialize(self, val):
         from colander import Invalid
+
         if self.exc:
             raise Invalid(self, self.exc)
         return val
 
     def serialize(self, val):
         from colander import Invalid
+
         if self.exc:
             raise Invalid(self, self.exc)
         return val
@@ -4370,6 +4479,7 @@ class DummyValidator(object):
 
     def __call__(self, node, value):
         from colander import Invalid
+
         if self.msg:
             e = Invalid(node, self.msg)
             self.children and e.children.extend(self.children)

--- a/colander/tests/test_interfaces.py
+++ b/colander/tests/test_interfaces.py
@@ -1,2 +1,3 @@
 def test_interfaces():
-    from colander import interfaces
+    # improve coverage checks for interfaces.py
+    from colander import interfaces  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+
+[tool.black]
+line-length = 79
+skip-string-normalization = true
+py36 = false
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | dist
+  | build
+  | docs
+)/
+'''
+
+# This next section only exists for people that have their editors
+# automatically call isort, black already sorts entries on its own when run.
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+combine_as_imports = true
+line_length = 79

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,21 @@ cover-erase=1
 dev = develop easy_install colander[testing]
 docs = develop easy_install colander[docs]
 
+[metadata]
+license_file = LICENSE.txt
+
+[check-manifest]
+ignore =
+    .gitignore
+    .hgignore
+    .flake8
+    PKG-INFO
+    *.egg-info
+    *.egg-info/*
+ignore-default-rules = true
+ignore-bad-ideas =
+    colander/locale/*
+
 [compile_catalog]
 directory = colander/locale
 domain = colander

--- a/setup.py
+++ b/setup.py
@@ -35,17 +35,14 @@ except Exception:
 requires = ['translationstring', 'iso8601']
 
 testing_extras = ['nose', 'coverage']
-docs_extras = [
-    'Sphinx >= 1.7.4',
-    'docutils',
-    'pylons-sphinx-themes',
-]
+docs_extras = ['Sphinx >= 1.7.4', 'docutils', 'pylons-sphinx-themes']
 
 setup(
     name='colander',
     version='1.5.1',
-    description=('A simple schema-based serialization and deserialization '
-                 'library'),
+    description=(
+        'A simple schema-based serialization and deserialization ' 'library'
+    ),
     long_description=README + '\n\n' + CHANGES,
     classifiers=[
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -11,22 +11,24 @@
 # FITNESS FOR A PARTICULAR PURPOSE
 #
 ##############################################################################
-
 import os
 
 from setuptools import setup
 from setuptools import find_packages
 
+
 here = os.path.abspath(os.path.dirname(__file__))
+
 
 def read(fname):
     with open(fname) as fp:
         return fp.read()
 
+
 try:
     README = read(os.path.join(here, 'README.rst'))
     CHANGES = read(os.path.join(here, 'CHANGES.rst'))
-except:
+except Exception:
     README = ''
     CHANGES = ''
 
@@ -39,37 +41,38 @@ docs_extras = [
     'pylons-sphinx-themes',
 ]
 
-setup(name='colander',
-      version='1.5.1',
-      description=('A simple schema-based serialization and deserialization '
-                   'library'),
-      long_description=README + '\n\n' + CHANGES,
-      classifiers=[
-          "Intended Audience :: Developers",
-          "Programming Language :: Python",
-          "Programming Language :: Python :: 2",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.4",
-          "Programming Language :: Python :: 3.5",
-          "Programming Language :: Python :: 3.6",
-          "Programming Language :: Python :: 3.7",
-          "Programming Language :: Python :: Implementation :: CPython",
-          "Programming Language :: Python :: Implementation :: PyPy",
-          ],
-      keywords='serialize deserialize validate schema validation',
-      author="Agendaless Consulting",
-      author_email="pylons-discuss@googlegroups.com",
-      url="https://docs.pylonsproject.org/projects/colander/en/latest/",
-      license="BSD-derived (http://www.repoze.org/LICENSE.txt)",
-      packages=find_packages(),
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=requires,
-      test_suite="colander",
-      extras_require={
-          ':python_version in "2.7,3.3"': ['enum34'],
-          'testing': testing_extras,
-          'docs': docs_extras,
-          },
-      )
+setup(
+    name='colander',
+    version='1.5.1',
+    description=('A simple schema-based serialization and deserialization '
+                 'library'),
+    long_description=README + '\n\n' + CHANGES,
+    classifiers=[
+        "Intended Audience :: Developers",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+    ],
+    keywords='serialize deserialize validate schema validation',
+    author="Agendaless Consulting",
+    author_email="pylons-discuss@googlegroups.com",
+    url="https://docs.pylonsproject.org/projects/colander/en/latest/",
+    license="BSD-derived (http://www.repoze.org/LICENSE.txt)",
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=requires,
+    test_suite="colander",
+    extras_require={
+        ':python_version in "2.7,3.3"': ['enum34'],
+        'testing': testing_extras,
+        'docs': docs_extras,
+    },
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    lint
     py27,py34,py35,py36,py37,py38,pypy,pypy3,
     docs,
     {py2,py3}-cover,coverage
@@ -63,3 +64,13 @@ deps =
     coverage
 setenv =
     COVERAGE_FILE=.coverage
+
+[testenv:lint]
+skip_install = true
+basepython = python3.6
+commands =
+    flake8 colander setup.py
+    python setup.py check -r -s -m
+deps =
+    flake8
+    readme_renderer

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     lint
     py27,py34,py35,py36,py37,py38,pypy,pypy3,
     docs,
-    {py2,py3}-cover,coverage
+    {py27,py36}-cover,coverage
 
 [testenv]
 # Most of these are defaults but if you specify any you can't fall back
@@ -41,20 +41,20 @@ commands =
     coverage run --source=colander {envbindir}/nosetests
     coverage xml -o {envname}.xml
 
-[testenv:py2-cover]
+[testenv:py27-cover]
 commands =
     {[py-cover]commands}
 setenv =
     COVERAGE_FILE=.coverage.py2
 
-[testenv:py3-cover]
+[testenv:py36-cover]
 commands =
     {[py-cover]commands}
 setenv =
     COVERAGE_FILE=.coverage.py3
 
 [testenv:coverage]
-basepython = python3.5
+basepython = python3.6
 commands =
     coverage erase
     coverage combine
@@ -70,7 +70,36 @@ skip_install = true
 basepython = python3.6
 commands =
     flake8 colander setup.py
-    python setup.py check -r -s -m
+    black --check --diff colander setup.py
+    python setup.py sdist --dist-dir {distdir}
+    twine check {distdir}/*
+    check-manifest
 deps =
     flake8
-    readme_renderer
+    black
+    readme_renderer[md]
+    check-manifest
+    twine
+
+[testenv:black]
+skip_install = true
+basepython = python3.6
+commands =
+    black colander setup.py
+deps =
+    black
+
+[testenv:build]
+skip_install = true
+basepython = python3.6
+commands =
+    # clean up build/ and dist/ folders
+    python -c 'import shutil; shutil.rmtree("dist", ignore_errors=True)'
+    python setup.py clean --all
+    # build sdist
+    python setup.py sdist --dist-dir {toxinidir}/dist
+    # build wheel from sdist
+    pip wheel -v --no-deps --no-index --no-build-isolation --wheel-dir {toxinidir}/dist --find-links {toxinidir}/dist colander
+deps =
+    setuptools
+    wheel

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     lint
     py27,py34,py35,py36,py37,py38,pypy,pypy3,
     docs,
-    {py27,py36}-cover,coverage
+    py36-cover,coverage
 
 [testenv]
 # Most of these are defaults but if you specify any you can't fall back
@@ -35,21 +35,11 @@ commands =
 # cobertura jenkins reporting and b) pypy and jython can't handle any
 # combination of versions of coverage and nosexcover that i can find.
 
-[py-cover]
+[testenv:py36-cover]
 commands =
     pip install colander[testing]
     coverage run --source=colander {envbindir}/nosetests
     coverage xml -o {envname}.xml
-
-[testenv:py27-cover]
-commands =
-    {[py-cover]commands}
-setenv =
-    COVERAGE_FILE=.coverage.py2
-
-[testenv:py36-cover]
-commands =
-    {[py-cover]commands}
 setenv =
     COVERAGE_FILE=.coverage.py3
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     lint
     py27,py34,py35,py36,py37,py38,pypy,pypy3,
     docs,
-    py36-cover,coverage
+    py{27,36}-cover,coverage
 
 [testenv]
 # Most of these are defaults but if you specify any you can't fall back
@@ -35,11 +35,21 @@ commands =
 # cobertura jenkins reporting and b) pypy and jython can't handle any
 # combination of versions of coverage and nosexcover that i can find.
 
-[testenv:py36-cover]
+[py-cover]
 commands =
     pip install colander[testing]
     coverage run --source=colander {envbindir}/nosetests
     coverage xml -o {envname}.xml
+
+[testenv:py27-cover]
+commands =
+    {[py-cover]commands}
+setenv =
+    COVERAGE_FILE=.coverage.py2
+
+[testenv:py36-cover]
+commands =
+    {[py-cover]commands}
 setenv =
     COVERAGE_FILE=.coverage.py3
 


### PR DESCRIPTION
Python code of ``colander`` formatted to conform to the PEP 8 style guide.
Added some linters (``flake8`` and ``setup.py check``) into ``tox.ini``.