### PR TITLE
Fix: email regex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Unreleased
+==========
+
+- The Email validator has been updated to use the same regular expression that
+  is used by the WhatWG HTML specification, thereby increasing the email
+  addresses that will validate correctly from web forms submitted. See
+  https://github.com/Pylons/colander/pull/324 and
+  https://github.com/Pylons/colander/issues/283
+
 1.6.0 (2019-01-31)
 ==================
 

--- a/colander/__init__.py
+++ b/colander/__init__.py
@@ -377,19 +377,17 @@ class Regex(object):
             raise Invalid(node, self.msg)
 
 
-EMAIL_RE = r"""(?ix) # matches case insensitive with spaces and comments
-                     # ignored for the entire expression
-^ # matches the start of string
-[A-Z0-9._!#$%&'*+\-/=?^_`{|}~()]+ # matches multiples of the characters:
-                                # A-Z0-9._!#$%&'*+-/=?^_`{|}~() one or
-                                # more times
-@ # matches the @ sign
-[A-Z0-9]+ # matches multiples of the characters A-Z0-9
-([.-][A-Z0-9]+)* # matches one of . or - followed by at least one of A-Z0-9,
-                 # zero to unlimited times
-\.[A-Z]{2,22} # matches a period, followed by two to twenty-two of A-Z
-$ # matches the end of the string
-"""
+# Regex for email addresses.
+#
+# Stolen from the WhatWG HTML spec:
+# https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)
+#
+# If it is good enough for browsers, it is good enough for us!
+EMAIL_RE = (
+    r"^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9]"
+    r"(?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9]"
+    r"(?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+)
 
 
 class Email(Regex):

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -491,9 +491,6 @@ class TestEmail(unittest.TestCase):
         from colander import Invalid
 
         self.assertRaises(Invalid, validator, None, 'me@here.')
-        self.assertRaises(
-            Invalid, validator, None, 'name@here.tldiswaytoolooooooooong'
-        )
         self.assertRaises(Invalid, validator, None, '@here.us')
         self.assertRaises(Invalid, validator, None, 'me@here..com')
         self.assertRaises(Invalid, validator, None, 'me@we-here-.com')

--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -480,6 +480,7 @@ class TestEmail(unittest.TestCase):
         self.assertEqual(validator(None, 'name@here1.info'), None)
         self.assertEqual(validator(None, 'foo@bar.baz.biz'), None)
         self.assertEqual(validator(None, "tip'oneill@house.gov"), None)
+        self.assertEqual(validator(None, "lorem@i--ipsum.com"), None)
 
     def test_empty_email(self):
         validator = self._makeOne()


### PR DESCRIPTION
This changes the Regex used for validating emails addresses to match the WhatWG HTML spec: https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)

The same validator is used by browsers for the `<input type="email">` validation.

Closes #283