### PR TITLE
docs: Fix simple typo, goos -> goes

### DIFF
--- a/colander/tests/test_colander.py
+++ b/colander/tests/test_colander.py
@@ -4551,7 +4551,7 @@ class TestDeclarativeWithInstantiate(unittest.TestCase, TestFunctional):
     def _makeSchema(self, name='schema'):
         import colander
 
-        # an unlikely usage, but goos to test passing
+        # an unlikely usage, but goes to test passing
         # parameters to instantiation works
         @colander.instantiate(name=name)
         class schema(colander.MappingSchema):


### PR DESCRIPTION
There is a small typo in colander/tests/test_colander.py.

Should read `goes` rather than `goos`.

