### PR TITLE
Deseralize date and datetime inputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ unreleased
 
 - Fix deserializer on ``Date`` and ``DateTime`` fields to correctly catch
   ``ValueError`` and ``TypeError`` exception, which can arise when using custom
-  formats on the field. Instead of allowing these exceptions to propogate
+  formats on the field. Instead of allowing these exceptions to propagate,
   replace then with an ``Invalid`` exception instead.
   See https://github.com/Pylons/colander/pull/338
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ unreleased
 
 - Add support for Python 3.7 and 3.8.
 
+- Fix deserializer on ``Date`` and ``DateTime`` fields to correctly catch
+  ``ValueError`` and ``TypeError`` exception, which can arise when using custom
+  formats on the field. Instead of allowing these exceptions to propogate
+  replace then with an ``Invalid`` exception instead.
+  See https://github.com/Pylons/colander/pull/338
+
 1.7.0 (2019-02-01)
 ==================
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -141,3 +141,4 @@ Contributors
 - Manuel Vázquez, 2018/11/22
 - Kirill Kuzminykh, 2019/01/27
 - Damian Dimmich, 2020/07/19
+- Keith M Franklin, 2020/07/30

--- a/src/colander/__init__.py
+++ b/src/colander/__init__.py
@@ -1882,7 +1882,7 @@ class DateTime(SchemaType):
                 result = iso8601.parse_date(
                     cstruct, default_timezone=self.default_tzinfo
                 )
-        except (ValueError, iso8601.ParseError) as e:
+        except (ValueError, TypeError, iso8601.ParseError) as e:
             raise Invalid(
                 node, _(self.err_template, mapping={'val': cstruct, 'err': e})
             )
@@ -1960,7 +1960,7 @@ class Date(SchemaType):
             else:
                 result = iso8601.parse_date(cstruct)
             result = result.date()
-        except iso8601.ParseError as e:
+        except (ValueError, TypeError, iso8601.ParseError) as e:
             raise Invalid(
                 node, _(self.err_template, mapping={'val': cstruct, 'err': e})
             )

--- a/tests/test_colander.py
+++ b/tests/test_colander.py
@@ -2640,6 +2640,7 @@ class TestDateTime(unittest.TestCase):
 
         class Anon:
             pass
+
         self.assertRaises(Invalid, typ.deserialize, node, Anon())
 
 
@@ -2765,6 +2766,7 @@ class TestDate(unittest.TestCase):
 
         class Anon:
             pass
+
         self.assertRaises(Invalid, typ.deserialize, node, Anon())
 
     def test_deserialize_date_with_incorrect_format(self):

--- a/tests/test_colander.py
+++ b/tests/test_colander.py
@@ -2631,6 +2631,17 @@ class TestDateTime(unittest.TestCase):
         self.assertEqual(result.isoformat(), dt.isoformat())
         self.assertEqual(result.tzinfo, None)
 
+    def test_deserialize_invalid_type(self):
+        from colander import Invalid
+
+        typ = self._makeOne(default_tzinfo=None, format='%d/%m/%Y')
+        node = DummySchemaNode(None)
+        self.assertRaises(Invalid, typ.deserialize, node, 10012001)
+
+        class Anon():
+            pass
+        self.assertRaises(Invalid, typ.deserialize, node, Anon())
+
 
 class TestDate(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
@@ -2744,6 +2755,25 @@ class TestDate(unittest.TestCase):
         node = DummySchemaNode(None)
         result = typ.deserialize(node, formatted)
         self.assertEqual(result, date)
+
+    def test_deserialize_date_with_custom_format_invalid_type(self):
+        from colander import Invalid
+
+        typ = self._makeOne(format='%d/%m/%Y')
+        node = DummySchemaNode(None)
+        self.assertRaises(Invalid, typ.deserialize, node, 123)
+
+        class Anon():
+            pass
+        self.assertRaises(Invalid, typ.deserialize, node, Anon())
+
+    def test_deserialize_date_with_incorrect_format(self):
+        from colander import Invalid
+
+        typ = self._makeOne(format='%d/%m/%Y')
+        node = DummySchemaNode(None)
+        self.assertRaises(Invalid, typ.deserialize, node, "2001-01-01")
+        self.assertRaises(Invalid, typ.deserialize, node, "01012001")
 
 
 class TestTime(unittest.TestCase):

--- a/tests/test_colander.py
+++ b/tests/test_colander.py
@@ -2638,7 +2638,7 @@ class TestDateTime(unittest.TestCase):
         node = DummySchemaNode(None)
         self.assertRaises(Invalid, typ.deserialize, node, 10012001)
 
-        class Anon():
+        class Anon:
             pass
         self.assertRaises(Invalid, typ.deserialize, node, Anon())
 
@@ -2763,7 +2763,7 @@ class TestDate(unittest.TestCase):
         node = DummySchemaNode(None)
         self.assertRaises(Invalid, typ.deserialize, node, 123)
 
-        class Anon():
+        class Anon:
             pass
         self.assertRaises(Invalid, typ.deserialize, node, Anon())
 


### PR DESCRIPTION
This pull request addresses issue #337 which I raised yesterday. 

I decided against the optional flag to force a cast to type string in case the format was defined.

As always any feedback more than welcomed