### PR TITLE
Correct insert_before functionality for deferred nodes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Unreleased
+==========
+
+- Fix handling of ``insert_before`` on deferred nodes so that it orders the
+  new node correctly instead of always appending to the end of
+  ``node.children`` after binding.
+
 1.8.2 (2020-08-07)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Unreleased
 ==========
 
-- Fix handling of ``insert_before`` on deferred nodes so that it orders the
-  new node correctly instead of always appending to the end of
+- Fix handling of ``insert_before`` on deferred nodes so that it inserts the
+  new node before the specified node instead of always appending to the end of
   ``node.children`` after binding.
 
 1.8.2 (2020-08-07)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -142,3 +142,4 @@ Contributors
 - Kirill Kuzminykh, 2019/01/27
 - Damian Dimmich, 2020/07/19
 - Keith M Franklin, 2020/07/30
+- Scott Maki, 2020/11/15

--- a/src/colander/__init__.py
+++ b/src/colander/__init__.py
@@ -2125,9 +2125,11 @@ def _add_node_child(node, child):
             del node[child.name]
         node.add_before(insert_before, child)
 
+
 def _add_node_children(node, children):
     for n in children:
         _add_node_child(node, n)
+
 
 class _SchemaNode(object):
     """

--- a/src/colander/__init__.py
+++ b/src/colander/__init__.py
@@ -2109,23 +2109,25 @@ class Enum(SchemaType):
         return self.values[result]
 
 
+def _add_node_child(node, child):
+    insert_before = getattr(child, 'insert_before', None)
+    exists = node.get(child.name, _marker) is not _marker
+    # use exists for microspeed; we could just call __setitem__
+    # exclusively, but it does an enumeration that's unnecessary in the
+    # common (nonexisting) case (.add is faster)
+    if insert_before is None:
+        if exists:
+            node[child.name] = child
+        else:
+            node.add(child)
+    else:
+        if exists:
+            del node[child.name]
+        node.add_before(insert_before, child)
+
 def _add_node_children(node, children):
     for n in children:
-        insert_before = getattr(n, 'insert_before', None)
-        exists = node.get(n.name, _marker) is not _marker
-        # use exists for microspeed; we could just call __setitem__
-        # exclusively, but it does an enumeration that's unnecessary in the
-        # common (nonexisting) case (.add is faster)
-        if insert_before is None:
-            if exists:
-                node[n.name] = n
-            else:
-                node.add(n)
-        else:
-            if exists:
-                del node[n.name]
-            node.add_before(insert_before, n)
-
+        _add_node_child(node, n)
 
 class _SchemaNode(object):
     """
@@ -2437,7 +2439,11 @@ class _SchemaNode(object):
             if isinstance(v, deferred):
                 v = v(self, kw)
                 if isinstance(v, SchemaNode):
-                    self[k] = v
+                    if not v.name:
+                        v.name = k
+                    if v.raw_title is _marker:
+                        v.title = k.replace('_', ' ').title()
+                    _add_node_child(self, v)
                 else:
                     setattr(self, k, v)
         if getattr(self, 'after_bind', None):

--- a/tests/test_colander.py
+++ b/tests/test_colander.py
@@ -3888,6 +3888,26 @@ class TestDeferred(unittest.TestCase):
         inst = self._makeOne(wrapped)
         self.assertEqual(inst.__doc__, None)
         self.assertFalse('__name__' in inst.__dict__)
+    
+    def test_deferred_with_insert_before(self):
+        def wrapped_func(node, kw):
+            return colander.SchemaNode(
+                colander.Int(),
+                insert_before='name2',
+            )
+        
+        deferred_node = self._makeOne(wrapped_func)
+        class MySchema(colander.Schema):
+            name2 = colander.SchemaNode(colander.Int())
+            name3 = colander.SchemaNode(colander.Int())
+            name1 = deferred_node
+            name4 = colander.SchemaNode(colander.Int())
+        
+        inst = MySchema().bind()
+        self.assertEqual(
+            [x.name for x in inst.children],
+            ['name1', 'name2', 'name3', 'name4'],
+        )
 
 
 class TestSchema(unittest.TestCase):

--- a/tests/test_colander.py
+++ b/tests/test_colander.py
@@ -3888,21 +3888,22 @@ class TestDeferred(unittest.TestCase):
         inst = self._makeOne(wrapped)
         self.assertEqual(inst.__doc__, None)
         self.assertFalse('__name__' in inst.__dict__)
-    
+
     def test_deferred_with_insert_before(self):
         def wrapped_func(node, kw):
             return colander.SchemaNode(
                 colander.Int(),
                 insert_before='name2',
             )
-        
+
         deferred_node = self._makeOne(wrapped_func)
+
         class MySchema(colander.Schema):
             name2 = colander.SchemaNode(colander.Int())
             name3 = colander.SchemaNode(colander.Int())
             name1 = deferred_node
             name4 = colander.SchemaNode(colander.Int())
-        
+
         inst = MySchema().bind()
         self.assertEqual(
             [x.name for x in inst.children],


### PR DESCRIPTION
After binding, deferred nodes currently are always appended to the end of the list of node children, and named according to their attribute name. This change sends those nodes through the same logic currently implemented in `_add_node_children` so that they can be ordered and named appropriately.

It does this by breaking out the logic inside the loop in `_add_node_children` into its own function -- `_add_node_child` -- to keep the rest of the logic as close to the original as possible, and allowing individual children to be added. If it is preferable to keep helper functions to a minimum, I could modify this to accomplish the same task using only `_add_node_children` and passing the deferred nodes in with a list.

This only allows node arguments such as `insert_before` to affect the ordering; deferred nodes that do not specify an ordering will still be added to the end of the list of children.

Edit: As an aside, should I be fixing those linting errors? They're unrelated to any of the code I changed and I wasn't sure if I should be changing those in this PR.