### PR TITLE
Add DataURL validator

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -143,3 +143,4 @@ Contributors
 - Damian Dimmich, 2020/07/19
 - Keith M Franklin, 2020/07/30
 - Scott Maki, 2020/11/15
+- Jens Troeger, 2022/07/03

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -83,6 +83,8 @@ Validators
 
   .. autoclass:: Email
 
+  .. autoclass:: DataURL
+
   .. autofunction:: luhnok
 
   .. attribute:: url

--- a/src/colander/__init__.py
+++ b/src/colander/__init__.py
@@ -1,9 +1,11 @@
 # coding=utf-8
+import base64
 import copy
 import datetime
 import decimal
 import functools
 import itertools
+import mimetypes
 import pprint
 import re
 import translationstring
@@ -401,6 +403,67 @@ class Email(Regex):
         if msg is None:
             msg = _("Invalid email address")
         super(Email, self).__init__(email_regex, msg=msg)
+
+
+# Regex for data URLs, loosely based on MDN:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
+DATA_URL_REGEX = (
+    # data: (required)
+    r'^data:'
+    # optional mime type
+    r'([^;]*)?'
+    # optional base64 identifier
+    r'(;base64)?'
+    # actual data follows the comma
+    r',(.*)$'
+)
+
+
+class DataURL(Regex):
+    """A data URL validator. If ``url_msg`` is supplied, it will be the error
+    message to be used when raising :exc:`colander.Invalid` for a syntactically
+    incorrect data URL, defaults to 'Not a data URL'. If, however, the data
+    URL string is syntactically correct but contains an invalid MIME type,
+    ``mimetype_err`` is raised (defaults to 'Invalid MIME type'); for incorrectly
+    encoded Base64 data, ``base64_err`` is raised (defaults to  'Invalid Base64
+    encoded data').
+    """
+
+    _URL_ERR = _("Not a data URL")
+    _MIMETYPE_ERR = _("Invalid MIME type")
+    _BASE64_ERR = _("Invalid Base64 encoded data")
+
+    def __init__(
+        self,
+        url_err=_URL_ERR,
+        mimetype_err=_MIMETYPE_ERR,
+        base64_err=_BASE64_ERR,
+    ):
+        data_url_regex = text_(DATA_URL_REGEX)
+        self.url_err = url_err
+        self.mimetype_err = mimetype_err
+        self.base64_err = base64_err
+        super(DataURL, self).__init__(
+            data_url_regex, msg=url_err, flags=re.IGNORECASE
+        )
+
+    def __call__(self, node, value):
+        match_ = self.match_object.match(value)
+        if match_ is None:
+            raise Invalid(node, self.url_err)
+        excs = []
+        mime, is_base64_data, data = match_.groups()
+        if mime and mime not in mimetypes.types_map.values():
+            excs.append(self.mimetype_err)
+        try:
+            if is_base64_data:
+                base64.standard_b64decode(data)
+        except Exception:
+            excs.append(self.base64_err)
+        if len(excs) == 1:
+            raise Invalid(node, excs[0])
+        elif len(excs) == 2:
+            raise Invalid(node, excs)
 
 
 class Range(object):


### PR DESCRIPTION
Closes #347 

As discussed in the linked issue, here’s a first stab at the `DataURL` validator. Locally I added `py39` and `py310` to 

https://github.com/Pylons/colander/blob/048fb24eeb6c3df21831413943dbf89d7b5776e4/tox.ini#L5

and perhaps that should also be added to the Github Actions (see PR https://github.com/Pylons/colander/pull/349)? I’ve not added translations to the locales.

**Question**: perhaps pass three `msg` args to the constructor for the three different errors; or raise just one error message for _all_ cases?