### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/manipulation.rst
+++ b/docs/manipulation.rst
@@ -89,7 +89,7 @@ The resulting flattened structure would look like this:
      'phones.1.number': '555-8989',
      }
 
-The process can be reversed using :meth:`colandar.SchemaNode.unflatten`:
+The process can be reversed using :meth:`colander.SchemaNode.unflatten`:
 
 .. code-block:: python
    :linenos:

--- a/src/colander/__init__.py
+++ b/src/colander/__init__.py
@@ -291,7 +291,7 @@ class Function(object):
     If the function returns a stringlike object (a ``str`` or
     ``unicode`` object) that is *not* the empty string , a
     :exc:`colander.Invalid` exception is raised using the stringlike
-    value returned from the function as the exeption message
+    value returned from the function as the exception message
     (validation fails).
 
     If the function returns anything *except* a stringlike object


### PR DESCRIPTION
There are small typos in:
- docs/manipulation.rst
- src/colander/__init__.py

Fixes:
- Should read `exception` rather than `exeption`.
- Should read `colander` rather than `colandar`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md