### PR TITLE
Fix instantiate decorator docstring typo

### DIFF
--- a/src/colander/__init__.py
+++ b/src/colander/__init__.py
@@ -2736,7 +2736,7 @@ class instantiate:
     A decorator which can be used to instantiate :class:`SchemaNode`
     elements inline within a class definition.
 
-    All parameters passed to the decorator and passed along to the
+    All parameters passed to the decorator are passed along to the
     :class:`SchemaNode` during instantiation.
     """
 


### PR DESCRIPTION
Fix `instantiate` class decorator docstring typo