### PR TITLE
fix: return empty flat map when container appstruct is null

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,12 @@
 [flake8]
 ignore =
-    # E731: do not assign a lambda expression, use a def,B042
+    # E731: do not assign a lambda expression, use a def
     E731
     # W503: line break before binary operator (flake8 is not PEP8 compliant)
     W503
     # W504: line break after binary operator (flake8 is not PEP8 compliant)
     W504
+    # B042: Invalid.__init__ documents and uses kwargs (msg/value); public API.
+    B042
 show-source = True
 max-line-length = 79

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 ignore =
-    # E731: do not assign a lambda expression, use a def
+    # E731: do not assign a lambda expression, use a def,B042
     E731
     # W503: line break before binary operator (flake8 is not PEP8 compliant)
     W503

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,7 +15,6 @@ jobs:
         strategy:
             matrix:
                 py:
-                    - "3.7"
                     - "3.8"
                     - "3.9"
                     - "3.10"
@@ -25,8 +24,7 @@ jobs:
                 os:
                     - "ubuntu-latest"
                     - "windows-latest"
-                    # later versions no longer support Python < 3.10.
-                    - "macos-11"
+                    - "macos-latest"
                 architecture:
                     - x64
                     - x86
@@ -34,7 +32,7 @@ jobs:
                     # Linux and macOS don't have x86 python
                     - os: "ubuntu-latest"
                       architecture: x86
-                    - os: "macos-11"
+                    - os: "macos-latest"
                       architecture: x86
         name: "Python: ${{ matrix.py }}-${{ matrix.architecture }} on ${{ matrix.os }}"
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -35,6 +35,10 @@ jobs:
                       architecture: x86
                     - os: "macos-13"
                       architecture: x86
+                    # setup-python has no Windows PyPy 3.8 x86 builds
+                    - os: "windows-latest"
+                      py: "pypy-3.8"
+                      architecture: x86
         name: "Python: ${{ matrix.py }}-${{ matrix.architecture }} on ${{ matrix.os }}"
         runs-on: ${{ matrix.os }}
         steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -13,6 +13,7 @@ on:
 jobs:
     test:
         strategy:
+            fail-fast: false
             matrix:
                 py:
                     - "3.8"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -25,7 +25,7 @@ jobs:
                 os:
                     - "ubuntu-latest"
                     - "windows-latest"
-                    - "macos-latest"
+                    - "macos-13"
                 architecture:
                     - x64
                     - x86
@@ -33,7 +33,7 @@ jobs:
                     # Linux and macOS don't have x86 python
                     - os: "ubuntu-latest"
                       architecture: x86
-                    - os: "macos-latest"
+                    - os: "macos-13"
                       architecture: x86
         name: "Python: ${{ matrix.py }}-${{ matrix.architecture }} on ${{ matrix.os }}"
         runs-on: ${{ matrix.os }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 # out serve to show the default value.
 
 import sys, os, datetime
-import pkg_resources
 import pylons_sphinx_themes
 
 # General configuration
@@ -41,7 +40,8 @@ copyright = '2012-%s, Agendaless Consulting <pylons-discuss@googlegroups.com>' %
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = pkg_resources.get_distribution('colander').version
+from importlib.metadata import version as _get_version
+version = _get_version('colander')
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/src/colander/__init__.py
+++ b/src/colander/__init__.py
@@ -957,6 +957,8 @@ class Mapping(SchemaType):
 
     def flatten(self, node, appstruct, prefix='', listitem=False):
         result = {}
+        if appstruct is null:
+            return result
         if listitem:
             selfprefix = prefix
         else:
@@ -1096,6 +1098,8 @@ class Tuple(Positional, SchemaType):
 
     def flatten(self, node, appstruct, prefix='', listitem=False):
         result = {}
+        if appstruct is null:
+            return result
         if listitem:
             selfprefix = prefix
         else:
@@ -1362,6 +1366,8 @@ class Sequence(Positional, SchemaType):
 
     def flatten(self, node, appstruct, prefix='', listitem=False):
         result = {}
+        if appstruct is null:
+            return result
         if listitem:
             selfprefix = prefix
         else:

--- a/tests/test_colander.py
+++ b/tests/test_colander.py
@@ -1124,6 +1124,14 @@ class TestMapping(unittest.TestCase):
         result = typ.flatten(node, {'a': 1, 'b': 2})
         self.assertEqual(result, {'node.appstruct': 2})
 
+    def test_flatten_null(self):
+        from colander import null
+
+        node = DummySchemaNode(None, name='node')
+        node.children = [DummySchemaNode(DummyType(), name='a')]
+        typ = self._makeOne()
+        self.assertEqual(typ.flatten(node, null), {})
+
     def test_flatten_listitem(self):
         node = DummySchemaNode(None, name='node')
         int1 = DummyType()
@@ -1370,6 +1378,17 @@ class TestTuple(unittest.TestCase):
         typ = self._makeOne()
         result = typ.flatten(node, (1, 2))
         self.assertEqual(result, {'node.appstruct': 2})
+
+    def test_flatten_null(self):
+        from colander import null
+
+        node = DummySchemaNode(None, name='node')
+        node.children = [
+            DummySchemaNode(DummyType(), name='a'),
+            DummySchemaNode(DummyType(), name='b'),
+        ]
+        typ = self._makeOne()
+        self.assertEqual(typ.flatten(node, null), {})
 
     def test_flatten_listitem(self):
         node = DummySchemaNode(None, name='node')
@@ -1731,6 +1750,14 @@ class TestSequence(unittest.TestCase):
         typ = self._makeOne()
         result = typ.flatten(node, [1, 2])
         self.assertEqual(result, {'node.0': 1, 'node.1': 2})
+
+    def test_flatten_null(self):
+        from colander import null
+
+        node = DummySchemaNode(None, name='node')
+        node.children = [DummySchemaNode(DummyType(), name='foo')]
+        typ = self._makeOne()
+        self.assertEqual(typ.flatten(node, null), {})
 
     def test_flatten_with_integer(self):
         from colander import Integer
@@ -4079,6 +4106,30 @@ class TestSchema(unittest.TestCase):
         expected = {'a': 'test'}
         result = node.deserialize(expected)
         self.assertEqual(result, expected)
+
+    def test_flatten_after_deserialize_drop_containers(self):
+        # missing=drop omits the key from the appstruct; flatten must not
+        # raise when Mapping walks that absent child as colander.null.
+        class Seq(colander.SequenceSchema):
+            item = colander.SchemaNode(colander.String())
+
+        class Tup(colander.TupleSchema):
+            x = colander.SchemaNode(colander.Int())
+            y = colander.SchemaNode(colander.Int())
+
+        class Inner(colander.MappingSchema):
+            z = colander.SchemaNode(colander.String())
+
+        class MySchema(colander.Schema):
+            title = colander.SchemaNode(colander.String())
+            items = Seq(missing=colander.drop)
+            point = Tup(missing=colander.drop)
+            inner = Inner(missing=colander.drop)
+
+        node = MySchema()
+        appstruct = node.deserialize({'title': 't'})
+        self.assertEqual(appstruct, {'title': 't'})
+        self.assertEqual(node.flatten(appstruct), {'title': 't'})
 
     def test_serialize_drop_default(self):
         class MySchema(colander.Schema):


### PR DESCRIPTION
Sequence.flatten hits TypeError when missing=drop sequence absent from appstruct. This PR fixes the regression with a focused test covering the case.
